### PR TITLE
Adds support for connection_uri GET request

### DIFF
--- a/neon_api/client.py
+++ b/neon_api/client.py
@@ -215,6 +215,20 @@ class NeonAPI:
 
         return self._request("GET", r_path)
 
+    @returns_model(schema.ConnectionUri)
+    def connection_uri(self, project_id: str, database_name: str = None, role_name: str = None, pooled: bool = False) -> t.Dict[str, t.Any]:
+        """Get a connection URI for a project.
+
+        :param project_id: The ID of the project.
+        :param database_name: The name of the database.
+        :param role_name: The name of the role.
+        :return: A dataclass representing the connection URI.
+
+        More info: https://api-docs.neon.tech/reference/getconnectionuri
+        """
+        r_params = compact_mapping({"database_name": database_name, "role_name": role_name, "pooled": pooled})
+        return self._request("GET", f"projects/{project_id}/connection_uri", params=r_params)
+
     @returns_model(schema.ProjectResponse)
     def project_create(self, **json: dict) -> t.Dict[str, t.Any]:
         """Create a new project. Accepts all keyword arguments for json body.

--- a/neon_api/schema.py
+++ b/neon_api/schema.py
@@ -185,6 +185,11 @@ class ConnectionDetails:
     connection_parameters: ConnectionParameters
 
 
+@dataclass
+class ConnectionUri:
+    uri: str
+
+
 class EndpointState(Enum):
     init = "init"
     active = "active"

--- a/tests/cassettes/test_integration/test_project.yaml
+++ b/tests/cassettes/test_integration/test_project.yaml
@@ -272,6 +272,44 @@ interactions:
       - application/json
       User-Agent:
       - neon-client/python version=(0.1.0)
+    method: GET
+    uri: https://console.neon.tech/api/v2/projects/icy-dream-08641192/connection_uri?database_name=neondb&role_name=neondb_owner&pooled=True
+  response:
+    body:
+      string: '{"uri":"postgres://kennethreitz:SfveBzuq78bs@ep-floral-shape-a5lure6e.us-east-2.aws.neon.tech/neondb?sslmode=require"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '965'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Feb 2024 14:04:03 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Origin
+      X-Neon-Ret-Request-Id:
+      - c2dc90aab245f1de6f981b1b99e0adb6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - neon-client/python version=(0.1.0)
     method: DELETE
     uri: https://console.neon.tech/api/v2/projects/icy-dream-08641192
   response:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -54,6 +54,8 @@ def test_project(neon, ensure_no_projects, random_name):
     for project in neon.projects(shared=True).projects:
         assert hasattr(project, "id")
 
+    neon.connection_uri(project.id, "neondb", "neondb_owner", True)
+
     # Delete the project.
     neon.project_delete(project.id)
 


### PR DESCRIPTION
This PR adds support for this missing endpoint in Neon's API (https://api-docs.neon.tech/reference/getconnectionuri).

```
>>> neon.connection_uri('twilight-king-17249571', 'neon_db', 'neondb_owner')
ConnectionUri(uri='postgresql://neondb_owner:bywO1ADn7Mse@ep-ancient-dew-a5la66a7-pooler.us-east-2.aws.neon.tech/neon_db?sslmode=require')

>>> neon.connection_uri('twilight-king-17249571', 'neon_db')
Traceback (most recent call last):
  File "/Users/david/src/neon-api-python/neon_api/client.py", line 117, in _request
    r.raise_for_status()
  File "/Users/david/src/neon-api-python/venv/lib/python3.12/site-packages/requests/models.py", line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://console.neon.tech/api/v2/projects/twilight-king-17249571/connection_uri?database_name=neon_db

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/david/src/neon-api-python/neon_api/client.py", line 39, in wrapper
    return model(**func(*args, **kwargs))
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/david/src/neon-api-python/neon_api/client.py", line 230, in connection_uri
    return self._request("GET", f"projects/{project_id}/connection_uri", params=r_params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/david/src/neon-api-python/neon_api/client.py", line 119, in _request
    raise NeonAPIError(r.text)
neon_api.exceptions.NeonAPIError: {"code":"","message":"invalid input"}
```

Also, `make test` works.