### PR TITLE
Bumps the OpenAPI schema used to generate the SDK

### DIFF
--- a/v2.json
+++ b/v2.json
@@ -7,7 +7,7 @@
     ],
     "info": {
         "title": "Neon API",
-        "description": "The Neon API allows you to access and manage Neon programmatically. You can use the Neon API to manage API keys, projects, branches, endpoints, databases, roles, and operations. For information about these features, refer to the [Neon documentation](https://neon.tech/docs/manage/overview/).\n\nYou can run Neon API requests from this API reference using the **Try It** feature provided for each method. Enter your API key as a **Bearer** token in the **Authoization** section of the page.\n\nYou can create and manage API keys in the Neon Console. See [Manage API keys](https://neon.tech/docs/manage/api-keys/) for instructions.",
+        "description": "The Neon API allows you to access and manage Neon programmatically. You can use the Neon API to manage API keys, projects, branches, compute endpoints, databases, roles, and operations. For information about these features, refer to the [Neon documentation](https://neon.tech/docs/manage/overview/).\n\nYou can run Neon API requests from this API reference using the **Try It** feature. Enter your API key as a **Bearer** token in the **Authoization** section of the page.\n\nYou can create and manage API keys in the Neon Console. See [Manage API keys](https://neon.tech/docs/manage/api-keys/) for instructions.",
         "version": "v2",
         "contact": {
             "email": "support@neon.tech"
@@ -22,6 +22,9 @@
         },
         {
             "CookieAuth": []
+        },
+        {
+            "TokenCookieAuth": []
         }
     ],
     "tags": [
@@ -50,139 +53,23 @@
             "description": "New API methods that are in a Preview state and may be subject to changes."
         },
         {
+            "name": "Region",
+            "description": "These methods allow you to inspect Neon regions."
+        },
+        {
             "name": "Users",
             "description": "These methods allow you to manage your Neon user account."
+        },
+        {
+            "name": "Consumption",
+            "description": "These methods allow you to view consumption details for your Neon account."
+        },
+        {
+            "name": "Organizations",
+            "description": "These methods allow you to manage your Neon organizations."
         }
     ],
     "paths": {
-        "/projects/{project_id}/applications/vercel": {
-            "parameters": [
-                {
-                    "name": "project_id",
-                    "description": "Neon project ID",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/projects/{project_id}/applications/vercel/vars": {
-            "parameters": [
-                {
-                    "name": "project_id",
-                    "description": "Neon project ID",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/projects/{project_id}/applications/polyscale/auth": {
-            "parameters": [
-                {
-                    "name": "project_id",
-                    "description": "Neon project ID",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/projects/applications/polyscale/auth/callback": {
-            "parameters": [
-                {
-                    "in": "query",
-                    "name": "code",
-                    "schema": {
-                        "type": "string"
-                    },
-                    "description": "code for token request in oauth"
-                },
-                {
-                    "in": "query",
-                    "name": "state",
-                    "schema": {
-                        "type": "string"
-                    },
-                    "description": "state parameter from oauth"
-                }
-            ]
-        },
-        "/projects/{project_id}/applications/polyscale/caches": {
-            "parameters": [
-                {
-                    "name": "project_id",
-                    "description": "Neon project ID",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/projects/{project_id}/applications/polyscale/caches/{cache_id}": {
-            "parameters": [
-                {
-                    "name": "project_id",
-                    "description": "Neon project ID",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "name": "cache_id",
-                    "description": "Polyscale cache ID, from getProjectPolyscaleCaches",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/projects/{project_id}/applications/polyscale/caches/{cache_id}/purge": {
-            "parameters": [
-                {
-                    "name": "project_id",
-                    "description": "Neon project ID",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "name": "cache_id",
-                    "description": "Polyscale cache ID, from getProjectPolyscaleCaches",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/applications/oauth/{client_id}": {
-            "parameters": [
-                {
-                    "name": "client_id",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
         "/api_keys": {
             "get": {
                 "summary": "Get a list of API keys",
@@ -206,6 +93,11 @@
                                             "id": 165432,
                                             "name": "mykey_1",
                                             "created_at": "2022-11-15T20:13:35Z",
+                                            "created_by": {
+                                                "id": "629982cc-de05-43db-ae16-28f2399c4910",
+                                                "name": "John Smith",
+                                                "image": "http://link.to.image"
+                                            },
                                             "last_used_at": "2022-11-15T20:22:51Z",
                                             "last_used_from_addr": "192.0.2.255"
                                         },
@@ -213,6 +105,11 @@
                                             "id": 165433,
                                             "name": "mykey_2",
                                             "created_at": "2022-11-15T20:12:36Z",
+                                            "created_by": {
+                                                "id": "629982cc-de05-43db-ae16-28f2399c4910",
+                                                "name": "John Smith",
+                                                "image": "http://link.to.image"
+                                            },
                                             "last_used_at": "2022-11-15T20:15:04Z",
                                             "last_used_from_addr": "192.0.2.255"
                                         }
@@ -257,8 +154,9 @@
                                 "example": {
                                     "id": 165434,
                                     "key": "9v1faketcjbl4sn1013keyd43n2a8qlfakeog8yvp40hx16keyjo1bpds4y2dfms3",
-                                    "name": "mykey_1",
-                                    "created_at": "2022-11-15T20:13:35Z"
+                                    "name": "mykey",
+                                    "created_at": "2022-11-15T20:13:35Z",
+                                    "created_by": "629982cc-de05-43db-ae16-28f2399c4910"
                                 }
                             }
                         }
@@ -300,9 +198,11 @@
                                 "example": {
                                     "id": 165435,
                                     "name": "mykey",
-                                    "revoked": true,
+                                    "created_at": "2022-11-15T20:13:35Z",
+                                    "created_by": "629982cc-de05-43db-ae16-28f2399c4910",
                                     "last_used_at": "2022-11-15T20:15:04Z",
-                                    "last_used_from_addr": "192.0.2.255"
+                                    "last_used_from_addr": "192.0.2.255",
+                                    "revoked": true
                                 }
                             }
                         }
@@ -321,7 +221,8 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -384,7 +285,7 @@
                 "parameters": [
                     {
                         "name": "cursor",
-                        "description": "Specify the cursor value from the previous response to get the next batch of projects.",
+                        "description": "Specify the cursor value from the previous response to retrieve the next batch of projects.",
                         "in": "query",
                         "schema": {
                             "type": "string"
@@ -400,6 +301,31 @@
                             "default": 10,
                             "maximum": 400
                         }
+                    },
+                    {
+                        "name": "search",
+                        "description": "Search by project `name` or `id`. You can specify partial `name` or `id` values to filter results.",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "org_id",
+                        "description": "Search for projects by `org_id`.",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        }
+                    },
+                    {
+                        "name": "timeout",
+                        "in": "query",
+                        "description": "Specify an explicit timeout in milliseconds to limit response delay.\nAfter timing out, the incomplete list of project data fetched so far will be returned.\nProjects still being fetched when the timeout occurred are listed in the \"unavailable\" attribute of the response.\nIf not specified, an implicit implementation defined timeout is chosen with the same behaviour as above\n",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "responses": {
@@ -414,6 +340,12 @@
                                         },
                                         {
                                             "$ref": "#/components/schemas/PaginationResponse"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/ProjectsApplicationsMapResponse"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/ProjectsIntegrationsMapResponse"
                                         }
                                     ]
                                 },
@@ -453,9 +385,22 @@
                                             "creation_source": "console",
                                             "store_passwords": true,
                                             "branch_logical_size_limit_bytes": 10800,
-                                            "active_time": 100
+                                            "active_time": 100,
+                                            "org_id": "org-morning-bread-81040908"
                                         }
-                                    ]
+                                    ],
+                                    "applications": {
+                                        "winter-boat-259881": [
+                                            "vercel",
+                                            "github"
+                                        ]
+                                    },
+                                    "integrations": {
+                                        "winter-boat-259881": [
+                                            "vercel",
+                                            "github"
+                                        ]
+                                    }
                                 }
                             }
                         }
@@ -467,7 +412,7 @@
             },
             "post": {
                 "summary": "Create a project",
-                "description": "Creates a Neon project.\nA project is the top-level object in the Neon object hierarchy.\nPlan limits define how many projects you can create.\nNeon's Free plan permits one project per Neon account.\nFor more information, see [Manage projects](https://neon.tech/docs/manage/projects/).\n\nYou can specify a region and PostgreSQL version in the request body.\nNeon currently supports PostgreSQL 14 and 15.\nFor supported regions and `region_id` values, see [Regions](https://neon.tech/docs/introduction/regions/).\n",
+                "description": "Creates a Neon project.\nA project is the top-level object in the Neon object hierarchy.\nPlan limits define how many projects you can create.\nFor more information, see [Manage projects](https://neon.tech/docs/manage/projects/).\n\nYou can specify a region and Postgres version in the request body.\nNeon currently supports PostgreSQL 14, 15, 16, and 17.\nFor supported regions and `region_id` values, see [Regions](https://neon.tech/docs/introduction/regions/).\n",
                 "tags": [
                     "Project"
                 ],
@@ -567,6 +512,14 @@
                             "default": 10,
                             "maximum": 400
                         }
+                    },
+                    {
+                        "name": "search",
+                        "description": "Search query by name or id.",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {
@@ -641,7 +594,8 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 }
             ],
@@ -676,9 +630,10 @@
                                         "cpu_used_sec": 10,
                                         "owner_id": "1232111",
                                         "owner": {
+                                            "name": "John Smith",
                                             "email": "some@email.com",
                                             "branches_limit": 10,
-                                            "subscription_type": "pro"
+                                            "subscription_type": "scale"
                                         },
                                         "creation_source": "console",
                                         "store_passwords": true,
@@ -857,7 +812,8 @@
                         "description": "The Neon project ID",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
                         }
                     }
                 ],
@@ -871,18 +827,6 @@
                 }
             }
         },
-        "/projects/{project_id}/saved_queries": {
-            "parameters": [
-                {
-                    "name": "project_id",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
         "/projects/{project_id}/permissions": {
             "parameters": [
                 {
@@ -890,20 +834,21 @@
                     "in": "path",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 }
             ],
             "get": {
-                "summary": "Return project's permissions",
-                "description": "Return project's permissions",
+                "summary": "List project access",
+                "description": "Retrieves details about users who have access to the project, including the permission `id`, the granted-to email address, and the date project access was granted.",
                 "tags": [
                     "Project"
                 ],
                 "operationId": "listProjectPermissions",
                 "responses": {
                     "200": {
-                        "description": "Successfully returned permissions",
+                        "description": "Returned project access details",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -918,8 +863,8 @@
                 }
             },
             "post": {
-                "summary": "Grant project permission to the user",
-                "description": "Grant project permission to the user",
+                "summary": "Grant project access",
+                "description": "Grants project access to the account associated with the specified email address",
                 "tags": [
                     "Project"
                 ],
@@ -936,7 +881,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Successfully granted permission to the user",
+                        "description": "Granted project access",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -958,7 +903,8 @@
                     "in": "path",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -971,15 +917,15 @@
                 }
             ],
             "delete": {
-                "summary": "Revoke permission from the user",
-                "description": "Revoke permission from the user",
+                "summary": "Revoke project access",
+                "description": "Revokes project access from the user associted with the specified permisison `id`. You can retrieve a user's permission `id` by listing project access.",
                 "tags": [
                     "Project"
                 ],
                 "operationId": "revokePermissionFromProject",
                 "responses": {
                     "200": {
-                        "description": "Successfully revoked permission from the user",
+                        "description": "Revoked project access",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -994,30 +940,205 @@
                 }
             }
         },
-        "/saved_queries/{saved_query_id}": {
-            "parameters": [
-                {
-                    "name": "saved_query_id",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int64"
-                    }
-                }
-            ]
-        },
-        "/projects/{project_id}/query/history": {
+        "/projects/{project_id}/jwks": {
             "parameters": [
                 {
                     "name": "project_id",
                     "in": "path",
+                    "description": "The Neon project ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Returns all available JWKS URLs for a project",
+                "description": "Returns all the available JWKS URLs that can be used for verifying JWTs used as the authentication mechanism for the specified project.\n",
+                "tags": [
+                    "Project"
+                ],
+                "operationId": "getProjectJWKS",
+                "responses": {
+                    "200": {
+                        "description": "The JWKS URLs available for the project",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProjectJWKSResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            },
+            "post": {
+                "summary": "Adds a JWKS URL to a project",
+                "description": "Add a new JWKS URL to a project, such that it can be used for verifying JWTs used as the authentication mechanism for the specified project.\n\nThe URL must be a valid HTTPS URL that returns a JSON Web Key Set.\n\nThe `provider_name` field allows you to specify which authentication provider you're using (e.g., Clerk, Auth0, AWS Cognito, etc.).\n\nThe `branch_id` can be used to specify on which branches the JWKS URL will be accepted. If not specified, then it will work on any branch.\n\nThe `role_names` can be used to specify for which roles the JWKS URL will be accepted.\n\nThe `jwt_audience` can be used to specify which \"aud\" values should be accepted by Neon in the JWTs that are used for authentication.\n",
+                "tags": [
+                    "Project"
+                ],
+                "operationId": "addProjectJWKS",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AddProjectJWKSRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "The JWKS URL was added to the project's authentication connections",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JWKSCreationOperation"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/projects/{project_id}/jwks/{jwks_id}": {
+            "parameters": [
+                {
+                    "name": "project_id",
+                    "in": "path",
+                    "description": "The Neon project ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    }
+                },
+                {
+                    "name": "jwks_id",
+                    "in": "path",
+                    "description": "The JWKS ID",
                     "required": true,
                     "schema": {
                         "type": "string"
                     }
                 }
-            ]
+            ],
+            "delete": {
+                "summary": "Delete a JWKS URL",
+                "description": "Deletes a JWKS URL from the specified project",
+                "tags": [
+                    "Project"
+                ],
+                "operationId": "deleteProjectJWKS",
+                "responses": {
+                    "200": {
+                        "description": "Deleted a JWKS URL from the project",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JWKS"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/projects/{project_id}/connection_uri": {
+            "get": {
+                "summary": "Get a connection URI",
+                "description": "Retrieves a connection URI for the specified database.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `database_name` by listing the databases for a branch.\nYou can obtain a `role_name` by listing the roles for a branch.\n",
+                "tags": [
+                    "Project"
+                ],
+                "operationId": "getConnectionURI",
+                "parameters": [
+                    {
+                        "name": "project_id",
+                        "in": "path",
+                        "description": "The Neon project ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        }
+                    },
+                    {
+                        "name": "branch_id",
+                        "in": "query",
+                        "description": "The branch ID. Defaults to your project's default `branch_id` if not specified.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        }
+                    },
+                    {
+                        "name": "endpoint_id",
+                        "in": "query",
+                        "description": "The endpoint ID. Defaults to the read-write `endpoint_id` associated with the `branch_id` if not specified.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        }
+                    },
+                    {
+                        "name": "database_name",
+                        "in": "query",
+                        "description": "The database name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "role_name",
+                        "in": "query",
+                        "description": "The role name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "pooled",
+                        "in": "query",
+                        "description": "Adds the `-pooler` option to the connection URI when set to `true`, creating a pooled connection URI.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returned the connection URI",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConnectionURIResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
         },
         "/projects/{project_id}/branches": {
             "parameters": [
@@ -1027,13 +1148,14 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 }
             ],
             "post": {
                 "summary": "Create a branch",
-                "description": "Creates a branch in the specified project.\nYou can obtain a `project_id` by listing the projects for your Neon account.\n\nThis method does not require a request body, but you can specify one to create an endpoint for the branch or to select a non-default parent branch.\nThe default behavior is to create a branch from the project's root branch (`main`) with no endpoint, and the branch name is auto-generated.\nFor related information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n",
+                "description": "Creates a branch in the specified project.\nYou can obtain a `project_id` by listing the projects for your Neon account.\n\nThis method does not require a request body, but you can specify one to create a compute endpoint for the branch or to select a non-default parent branch.\nThe default behavior is to create a branch from the project's default branch with no compute endpoint, and the branch name is auto-generated.\nThere is a maximum of one read-write endpoint per branch.\nA branch can have multiple read-only endpoints.\nFor related information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n",
                 "tags": [
                     "Branch"
                 ],
@@ -1042,7 +1164,14 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/BranchCreateRequest"
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/BranchCreateRequest"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/AnnotationCreateValueRequest"
+                                    }
+                                ]
                             },
                             "examples": {
                                 "branch_only": {
@@ -1089,13 +1218,56 @@
                     "Branch"
                 ],
                 "operationId": "listProjectBranches",
+                "parameters": [
+                    {
+                        "name": "search",
+                        "description": "Search by branch `name` or `id`. You can specify partial `name` or `id` values to filter results.",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "sort_by",
+                        "description": "Sort the branches by sort_field. If not provided, branches will be sorted by updated_at descending order",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "default": "updated_at",
+                            "enum": [
+                                "name",
+                                "created_at",
+                                "updated_at"
+                            ]
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/CursorParam"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SortOrderParam"
+                    },
+                    {
+                        "$ref": "#/components/parameters/LimitParam"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Returned a list of branches for the specified project",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/BranchesResponse"
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/BranchesResponse"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/AnnotationsMapResponse"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/CursorPaginationResponse"
+                                        }
+                                    ]
                                 },
                                 "example": {
                                     "branches": [
@@ -1104,6 +1276,7 @@
                                             "project_id": "shiny-wind-028834",
                                             "name": "main",
                                             "current_state": "ready",
+                                            "state_changed_at": "2022-11-30T20:09:48Z",
                                             "logical_size": 28,
                                             "created_at": "2022-11-23T17:42:25Z",
                                             "updated_at": "2022-11-23T17:42:26Z",
@@ -1112,7 +1285,8 @@
                                             "compute_time_seconds": 100,
                                             "active_time_seconds": 100,
                                             "cpu_used_sec": 100,
-                                            "primary": true,
+                                            "default": true,
+                                            "protected": false,
                                             "creation_source": "console"
                                         },
                                         {
@@ -1122,6 +1296,7 @@
                                             "parent_lsn": "0/1DE2850",
                                             "name": "dev2",
                                             "current_state": "ready",
+                                            "state_changed_at": "2022-11-30T20:09:48Z",
                                             "logical_size": 28,
                                             "created_at": "2022-11-30T19:09:48Z",
                                             "updated_at": "2022-11-30T19:09:49Z",
@@ -1130,7 +1305,8 @@
                                             "compute_time_seconds": 100,
                                             "active_time_seconds": 100,
                                             "cpu_used_sec": 100,
-                                            "primary": true,
+                                            "default": true,
+                                            "protected": false,
                                             "creation_source": "console"
                                         },
                                         {
@@ -1140,6 +1316,7 @@
                                             "parent_lsn": "0/19623D8",
                                             "name": "dev1",
                                             "current_state": "ready",
+                                            "state_changed_at": "2022-11-30T20:09:48Z",
                                             "logical_size": 21,
                                             "created_at": "2022-11-30T17:36:57Z",
                                             "updated_at": "2022-11-30T17:36:57Z",
@@ -1148,16 +1325,87 @@
                                             "compute_time_seconds": 100,
                                             "active_time_seconds": 100,
                                             "cpu_used_sec": 100,
-                                            "primary": true,
+                                            "default": true,
+                                            "protected": false,
                                             "creation_source": "console"
                                         }
-                                    ]
+                                    ],
+                                    "annotations": {
+                                        "br-aged-salad-637688": {
+                                            "object": {
+                                                "type": "console/branch",
+                                                "id": "br-aged-salad-637688"
+                                            },
+                                            "value": {
+                                                "vercel-commit-ref": "test"
+                                            },
+                                            "created_at": "2022-11-23T17:42:25Z",
+                                            "updated_at": "2022-11-23T17:42:26Z"
+                                        }
+                                    },
+                                    "pagination": {
+                                        "next": "eyJjcmVhdGV",
+                                        "previous": "eyJjcmVhdGV",
+                                        "sort_by": "updated_at",
+                                        "sort_order": "desc"
+                                    }
                                 }
                             }
                         }
                     },
                     "default": {
                         "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/projects/{project_id}/branches/count": {
+            "parameters": [
+                {
+                    "name": "project_id",
+                    "in": "path",
+                    "description": "The Neon project ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Get the total number of branches in a project",
+                "description": "Retrieves the total number of branches in the specified project.\nYou can obtain a `project_id` by listing the projects for your Neon account.\n",
+                "tags": [
+                    "Branch"
+                ],
+                "operationId": "countProjectBranches",
+                "parameters": [
+                    {
+                        "name": "search",
+                        "description": "Count branches matching the `name` in search query",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    },
+                    "200": {
+                        "description": "Returned a count of branches for the specified project",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/BranchesCountResponse"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1170,7 +1418,8 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -1179,13 +1428,14 @@
                     "description": "The branch ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 }
             ],
             "get": {
                 "summary": "Get branch details",
-                "description": "Retrieves information about the specified branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain a `branch_id` by listing the project's branches.\nA `branch_id` value has a `br-` prefix.\n\nEach Neon project has a root branch named `main`.\nA project may contain child branches that were branched from `main` or from another branch.\nA parent branch is identified by a `parent_id` value, which is the `id` of the parent branch.\nFor related information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n",
+                "description": "Retrieves information about the specified branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain a `branch_id` by listing the project's branches.\nA `branch_id` value has a `br-` prefix.\n\nEach Neon project is initially created with a root and default branch named `main`.\nA project can contain one or more branches.\nA parent branch is identified by a `parent_id` value, which is the `id` of the parent branch.\nFor related information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n",
                 "tags": [
                     "Branch"
                 ],
@@ -1196,7 +1446,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/BranchResponse"
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/BranchResponse"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/AnnotationResponse"
+                                        }
+                                    ]
                                 },
                                 "example": {
                                     "branch": {
@@ -1204,6 +1461,7 @@
                                         "project_id": "shiny-wind-028834",
                                         "name": "main",
                                         "current_state": "ready",
+                                        "state_changed_at": "2022-11-30T20:09:48Z",
                                         "logical_size": 28,
                                         "created_at": "2022-11-23T17:42:25Z",
                                         "updated_at": "2022-11-23T17:42:26Z",
@@ -1212,8 +1470,20 @@
                                         "compute_time_seconds": 100,
                                         "active_time_seconds": 100,
                                         "cpu_used_sec": 100,
-                                        "primary": true,
+                                        "default": true,
+                                        "protected": false,
                                         "creation_source": "console"
+                                    },
+                                    "annotation": {
+                                        "object": {
+                                            "type": "console/branch",
+                                            "id": "br-aged-salad-637688"
+                                        },
+                                        "value": {
+                                            "vercel-commit-ref": "test"
+                                        },
+                                        "created_at": "2022-11-23T17:42:25Z",
+                                        "updated_at": "2022-11-23T17:42:26Z"
                                     }
                                 }
                             }
@@ -1226,7 +1496,7 @@
             },
             "delete": {
                 "summary": "Delete a branch",
-                "description": "Deletes the specified branch from a project, and places\nall endpoints into an idle state, breaking existing client connections.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain a `branch_id` by listing the project's branches.\nFor related information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n\nWhen a successful response status is received, the endpoints are still active,\nand the branch is not yet deleted from storage.\nThe deletion occurs after all operations finish.\nYou cannot delete a branch if it is the only remaining branch in the project.\nA project must have at least one branch.\n",
+                "description": "Deletes the specified branch from a project, and places\nall compute endpoints into an idle state, breaking existing client connections.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain a `branch_id` by listing the project's branches.\nFor related information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n\nWhen a successful response status is received, the compute endpoints are still active,\nand the branch is not yet deleted from storage.\nThe deletion occurs after all operations finish.\nYou cannot delete a project's root or default branch, and you cannot delete a branch that has a child branch.\nA project must have at least one branch.\n",
                 "tags": [
                     "Branch"
                 ],
@@ -1245,6 +1515,7 @@
                                         "project_id": "shiny-wind-028834",
                                         "name": "main",
                                         "current_state": "ready",
+                                        "state_changed_at": "2022-11-30T20:09:48Z",
                                         "logical_size": 28,
                                         "created_at": "2022-11-23T17:42:25Z",
                                         "updated_at": "2022-11-23T17:42:26Z",
@@ -1253,7 +1524,8 @@
                                         "compute_time_seconds": 100,
                                         "active_time_seconds": 100,
                                         "cpu_used_sec": 100,
-                                        "primary": true,
+                                        "default": true,
+                                        "protected": false,
                                         "creation_source": "console"
                                     },
                                     "operations": [
@@ -1285,6 +1557,9 @@
                             }
                         }
                     },
+                    "204": {
+                        "description": "Returned if the branch doesn't exist or has already been deleted"
+                    },
                     "default": {
                         "$ref": "#/components/responses/GeneralError"
                     }
@@ -1295,7 +1570,7 @@
                     "Branch"
                 ],
                 "summary": "Update a branch",
-                "description": "Updates the specified branch. Only changing the branch name is supported.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nFor more information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n",
+                "description": "Updates the specified branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nFor more information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n",
                 "operationId": "updateProjectBranch",
                 "requestBody": {
                     "content": {
@@ -1328,6 +1603,7 @@
                                         "parent_lsn": "0/1E19478",
                                         "name": "mybranch",
                                         "current_state": "ready",
+                                        "state_changed_at": "2022-11-30T20:09:48Z",
                                         "created_at": "2022-11-23T17:42:25Z",
                                         "updated_at": "2022-11-23T17:42:26Z",
                                         "data_transfer_bytes": 1000000,
@@ -1335,7 +1611,8 @@
                                         "compute_time_seconds": 100,
                                         "active_time_seconds": 100,
                                         "cpu_used_sec": 100,
-                                        "primary": true,
+                                        "default": true,
+                                        "protected": false,
                                         "creation_source": "console"
                                     },
                                     "operations": []
@@ -1349,7 +1626,240 @@
                 }
             }
         },
-        "/projects/{project_id}/branches/{branch_id}/set_as_primary": {
+        "/projects/{project_id}/branches/{branch_id}/restore": {
+            "post": {
+                "tags": [
+                    "Branch"
+                ],
+                "summary": "Restore a branch",
+                "description": "Restores a branch to an earlier state in its own or another branch's history",
+                "operationId": "restoreProjectBranch",
+                "parameters": [
+                    {
+                        "name": "project_id",
+                        "in": "path",
+                        "description": "The Neon project ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        }
+                    },
+                    {
+                        "name": "branch_id",
+                        "in": "path",
+                        "description": "The branch ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BranchRestoreRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated the specified branch",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BranchOperations"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/projects/{project_id}/branches/{branch_id}/schema": {
+            "get": {
+                "tags": [
+                    "Branch"
+                ],
+                "summary": "Get the database schema",
+                "description": "Retrieves the schema from the specified database. The `lsn` and `timestamp` values cannot be specified at the same time. If both are omitted, the database schema is retrieved from database's head.",
+                "operationId": "getProjectBranchSchema",
+                "parameters": [
+                    {
+                        "name": "project_id",
+                        "in": "path",
+                        "description": "The Neon project ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        }
+                    },
+                    {
+                        "name": "branch_id",
+                        "in": "path",
+                        "description": "The branch ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        }
+                    },
+                    {
+                        "name": "db_name",
+                        "in": "query",
+                        "description": "Name of the database for which the schema is retrieved",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "lsn",
+                        "in": "query",
+                        "description": "The Log Sequence Number (LSN) for which the schema is retrieved\n",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "timestamp",
+                        "in": "query",
+                        "description": "The point in time for which the schema is retrieved\n",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2022-11-30T20:09:48Z"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Schema definition",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BranchSchemaResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/projects/{project_id}/branches/{branch_id}/compare_schema": {
+            "get": {
+                "tags": [
+                    "Branch"
+                ],
+                "summary": "Compare the database schema with another branch's schema",
+                "description": "Compares the schema from the specified database with another branch's schema. Hidden from the public spec.",
+                "operationId": "getProjectBranchSchemaComparison",
+                "parameters": [
+                    {
+                        "name": "project_id",
+                        "in": "path",
+                        "description": "The Neon project ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        }
+                    },
+                    {
+                        "name": "branch_id",
+                        "in": "path",
+                        "description": "The branch ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        }
+                    },
+                    {
+                        "name": "base_branch_id",
+                        "in": "query",
+                        "description": "The branch ID to compare the schema with",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        }
+                    },
+                    {
+                        "name": "db_name",
+                        "in": "query",
+                        "description": "Name of the database for which the schema is retrieved",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "lsn",
+                        "in": "query",
+                        "description": "The Log Sequence Number (LSN) for which the schema is retrieved\n",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "timestamp",
+                        "in": "query",
+                        "description": "The point in time for which the schema is retrieved\n",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2022-11-30T20:09:48Z"
+                        }
+                    },
+                    {
+                        "name": "base_lsn",
+                        "in": "query",
+                        "description": "The Log Sequence Number (LSN) for the base branch schema\n",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "base_timestamp",
+                        "in": "query",
+                        "description": "The point in time for the base branch schema\n",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2022-11-30T20:09:48Z"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Difference between the schemas",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BranchSchemaCompareResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/projects/{project_id}/branches/{branch_id}/set_as_default": {
             "parameters": [
                 {
                     "name": "project_id",
@@ -1357,7 +1867,8 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -1366,7 +1877,8 @@
                     "description": "The branch ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 }
             ],
@@ -1374,9 +1886,9 @@
                 "tags": [
                     "Branch"
                 ],
-                "summary": "Set the branch as the primary branch of a project",
-                "description": "The primary mark is automatically removed from the previous primary branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nFor more information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n",
-                "operationId": "setPrimaryProjectBranch",
+                "summary": "Set branch as default",
+                "description": "Sets the specified branch as the project's default branch.\nThe default designation is automatically removed from the previous default branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nFor more information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n",
+                "operationId": "setDefaultProjectBranch",
                 "responses": {
                     "200": {
                         "description": "Updated the specified branch",
@@ -1398,9 +1910,11 @@
                                         "parent_lsn": "0/1E19478",
                                         "name": "mybranch",
                                         "current_state": "ready",
+                                        "state_changed_at": "2022-11-30T20:09:48Z",
                                         "created_at": "2022-11-23T17:42:25Z",
                                         "updated_at": "2022-11-23T17:42:26Z",
-                                        "primary": true,
+                                        "default": true,
+                                        "protected": false,
                                         "creation_source": "console"
                                     },
                                     "operations": []
@@ -1422,7 +1936,8 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -1431,13 +1946,14 @@
                     "description": "The branch ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 }
             ],
             "get": {
                 "summary": "Get a list of branch endpoints",
-                "description": "Retrieves a list of endpoints for the specified branch.\nCurrently, Neon permits only one endpoint per branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\n",
+                "description": "Retrieves a list of compute endpoints for the specified branch.\nNeon permits only one read-write compute endpoint per branch.\nA branch can have multiple read-only compute endpoints.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\n",
                 "tags": [
                     "Branch"
                 ],
@@ -1496,7 +2012,8 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -1505,7 +2022,8 @@
                     "description": "The branch ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 }
             ],
@@ -1636,7 +2154,8 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -1645,7 +2164,8 @@
                     "description": "The branch ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -1660,7 +2180,7 @@
             ],
             "get": {
                 "summary": "Get database details",
-                "description": "Retrieves information about the specified database.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` and `database_name` by listing branch's databases.\nFor related information, see [Manage databases](https://neon.tech/docs/manage/databases/).\n",
+                "description": "Retrieves information about the specified database.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` and `database_name` by listing the branch's databases.\nFor related information, see [Manage databases](https://neon.tech/docs/manage/databases/).\n",
                 "tags": [
                     "Branch"
                 ],
@@ -1768,7 +2288,7 @@
             },
             "delete": {
                 "summary": "Delete a database",
-                "description": "Deletes the specified database from the branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` and `database_name` by listing branch's databases.\nFor related information, see [Manage databases](https://neon.tech/docs/manage/databases/).\n",
+                "description": "Deletes the specified database from the branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` and `database_name` by listing the branch's databases.\nFor related information, see [Manage databases](https://neon.tech/docs/manage/databases/).\n",
                 "tags": [
                     "Branch"
                 ],
@@ -1820,6 +2340,9 @@
                             }
                         }
                     },
+                    "204": {
+                        "description": "Returned if the database doesn't exist or has already been deleted"
+                    },
                     "default": {
                         "$ref": "#/components/responses/GeneralError"
                     }
@@ -1834,7 +2357,8 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -1843,13 +2367,14 @@
                     "description": "The branch ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 }
             ],
             "get": {
                 "summary": "Get a list of roles",
-                "description": "Retrieves a list of roles from the specified branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nIn Neon, the terms \"role\" and \"user\" are synonymous.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n",
+                "description": "Retrieves a list of Postgres roles from the specified branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n",
                 "tags": [
                     "Branch"
                 ],
@@ -1890,7 +2415,7 @@
             },
             "post": {
                 "summary": "Create a role",
-                "description": "Creates a role in the specified branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nIn Neon, the terms \"role\" and \"user\" are synonymous.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n\nConnections established to the active compute endpoint will be dropped.\nIf the compute endpoint is idle, the endpoint becomes active for a short period of time and is suspended afterward.\n",
+                "description": "Creates a Postgres role in the specified branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n\nConnections established to the active compute endpoint will be dropped.\nIf the compute endpoint is idle, the endpoint becomes active for a short period of time and is suspended afterward.\n",
                 "tags": [
                     "Branch"
                 ],
@@ -1959,7 +2484,8 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -1968,7 +2494,8 @@
                     "description": "The branch ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -1990,7 +2517,7 @@
                 "operationId": "getProjectBranchRole",
                 "responses": {
                     "200": {
-                        "description": "Successfully returned details for the specified role",
+                        "description": "Returned details for the specified role",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2015,7 +2542,7 @@
             },
             "delete": {
                 "summary": "Delete a role",
-                "description": "Deletes the specified role from the branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nYou can obtain the `role_name` by listing the roles for a branch.\nIn Neon, the terms \"role\" and \"user\" are synonymous.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n",
+                "description": "Deletes the specified Postgres role from the branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nYou can obtain the `role_name` by listing the roles for a branch.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n",
                 "tags": [
                     "Branch"
                 ],
@@ -2066,6 +2593,9 @@
                             }
                         }
                     },
+                    "204": {
+                        "description": "Returned if the role doesn't exist or has already been deleted"
+                    },
                     "default": {
                         "$ref": "#/components/responses/GeneralError"
                     }
@@ -2080,7 +2610,8 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -2089,7 +2620,8 @@
                     "description": "The branch ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -2104,14 +2636,14 @@
             ],
             "get": {
                 "summary": "Get role password",
-                "description": "Retrieves the password for the specified role, if possible.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nYou can obtain the `role_name` by listing the roles for a branch.\nIn Neon, the terms \"role\" and \"user\" are synonymous.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n",
+                "description": "Retrieves the password for the specified Postgres role, if possible.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nYou can obtain the `role_name` by listing the roles for a branch.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n",
                 "tags": [
                     "Branch"
                 ],
                 "operationId": "getProjectBranchRolePassword",
                 "responses": {
                     "200": {
-                        "description": "Successfully returned password for the specified role",
+                        "description": "Returned password for the specified role",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2157,7 +2689,8 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -2166,7 +2699,8 @@
                     "description": "The branch ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -2181,7 +2715,7 @@
             ],
             "post": {
                 "summary": "Reset the role password",
-                "description": "Resets the password for the specified role.\nReturns a new password and operations. The new password is ready to use when the last operation finishes.\nThe old password remains valid until last operation finishes.\nConnections to the compute endpoint are dropped. If idle,\nthe compute endpoint becomes active for a short period of time.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nYou can obtain the `role_name` by listing the roles for a branch.\nIn Neon, the terms \"role\" and \"user\" are synonymous.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n",
+                "description": "Resets the password for the specified Postgres role.\nReturns a new password and operations. The new password is ready to use when the last operation finishes.\nThe old password remains valid until last operation finishes.\nConnections to the compute endpoint are dropped. If idle,\nthe compute endpoint becomes active for a short period of time.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nYou can obtain the `role_name` by listing the roles for a branch.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n",
                 "tags": [
                     "Branch"
                 ],
@@ -2239,6 +2773,108 @@
                 }
             }
         },
+        "/projects/{project_id}/vpc_endpoints": {
+            "parameters": [
+                {
+                    "name": "project_id",
+                    "in": "path",
+                    "description": "The Neon project ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Get the list of VPC endpoint restrictions",
+                "description": "Retrieves the list of VPC endpoint restrictions for the specified project.\nThis endpoint is under active development and its semantics may change in the future.\n",
+                "tags": [
+                    "Project"
+                ],
+                "operationId": "listProjectVPCEndpoints",
+                "responses": {
+                    "200": {
+                        "description": "The list of configured VPC endpoint restrictions for the specified project",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VPCEndpointsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/projects/{project_id}/vpc_endpoints/{vpc_endpoint_id}": {
+            "parameters": [
+                {
+                    "name": "project_id",
+                    "in": "path",
+                    "description": "The Neon project ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    }
+                },
+                {
+                    "name": "vpc_endpoint_id",
+                    "in": "path",
+                    "description": "The VPC endpoint ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "post": {
+                "summary": "Assign or update a VPC endpoint restriction",
+                "description": "Configures the specified VPC endpoint as restriction for the project,\nor updates the existing restriction. When a VPC endpoint is assigned\nas a restriction, only connections from this specific VPC are accepted.\nNote that a VPC endpoint can only used as a restriction on a project\nafter it has been assigned to the parent organization.\nThis endpoint is under active development and its semantics may change in the future.\n",
+                "tags": [
+                    "Project"
+                ],
+                "operationId": "assignProjectVPCEndpoint",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/VPCEndpointAssignment"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Configured the specified VPC endpoint as a restriction for the specified project."
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete a VPC endpoint",
+                "description": "Deletes the specified VPC endpoint restriction from the specified project.\nThis endpoint is under active development and its semantics may change in the future.\n",
+                "tags": [
+                    "Project"
+                ],
+                "operationId": "deleteProjectVPCEndpoint",
+                "responses": {
+                    "200": {
+                        "description": "Deleted the specified VPC endpoint restriction from the specified project"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
         "/projects/{project_id}/endpoints": {
             "parameters": [
                 {
@@ -2247,13 +2883,14 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 }
             ],
             "post": {
-                "summary": "Create an endpoint",
-                "description": "Creates an endpoint for the specified branch.\nAn endpoint is a Neon compute instance.\nThere is a maximum of one read-write endpoint per branch.\nIf the specified branch already has a read-write endpoint, the operation fails.\nA branch can have multiple read-only endpoints.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain `branch_id` by listing the project's branches.\nA `branch_id` has a `br-` prefix.\nFor supported regions and `region_id` values, see [Regions](https://neon.tech/docs/introduction/regions/).\nFor more information about endpoints, see [Manage endpoints](https://neon.tech/docs/manage/endpoints/).\n",
+                "summary": "Create a compute endpoint",
+                "description": "Creates a compute endpoint for the specified branch.\nAn endpoint is a Neon compute instance.\nThere is a maximum of one read-write compute endpoint per branch.\nIf the specified branch already has a read-write compute endpoint, the operation fails.\nA branch can have multiple read-only compute endpoints.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain `branch_id` by listing the project's branches.\nA `branch_id` has a `br-` prefix.\nFor supported regions and `region_id` values, see [Regions](https://neon.tech/docs/introduction/regions/).\nFor more information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
                 "tags": [
                     "Endpoint"
                 ],
@@ -2301,7 +2938,7 @@
                 },
                 "responses": {
                     "201": {
-                        "description": "Created an endpoint",
+                        "description": "Created a compute endpoint",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2357,8 +2994,8 @@
                 }
             },
             "get": {
-                "summary": "Get a list of endpoints",
-                "description": "Retrieves a list of endpoints for the specified project.\nAn endpoint is a Neon compute instance.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nFor more information about endpoints, see [Manage endpoints](https://neon.tech/docs/manage/endpoints/).\n",
+                "summary": "Get a list of compute endpoints",
+                "description": "Retrieves a list of compute endpoints for the specified project.\nA compute endpoint is a Neon compute instance.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nFor information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
                 "tags": [
                     "Endpoint"
                 ],
@@ -2467,7 +3104,8 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -2476,13 +3114,14 @@
                     "description": "The endpoint ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 }
             ],
             "get": {
-                "summary": "Get an endpoint",
-                "description": "Retrieves information about the specified endpoint.\nAn endpoint is a Neon compute instance.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor more information about endpoints, see [Manage endpoints](https://neon.tech/docs/manage/endpoints/).\n",
+                "summary": "Get a compute endpoint",
+                "description": "Retrieves information about the specified compute endpoint.\nA compute endpoint is a Neon compute instance.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's compute endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
                 "tags": [
                     "Endpoint"
                 ],
@@ -2531,15 +3170,15 @@
                 }
             },
             "delete": {
-                "summary": "Delete an endpoint",
-                "description": "Delete the specified endpoint.\nAn endpoint is a Neon compute instance.\nDeleting an endpoint drops existing network connections to the endpoint.\nThe deletion is completed when last operation in the chain finishes successfully.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor more information about endpoints, see [Manage endpoints](https://neon.tech/docs/manage/endpoints/).\n",
+                "summary": "Delete a compute endpoint",
+                "description": "Delete the specified compute endpoint.\nA compute endpoint is a Neon compute instance.\nDeleting a compute endpoint drops existing network connections to the compute endpoint.\nThe deletion is completed when last operation in the chain finishes successfully.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's compute endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
                 "tags": [
                     "Endpoint"
                 ],
                 "operationId": "deleteProjectEndpoint",
                 "responses": {
                     "200": {
-                        "description": "Deleted the specified endpoint",
+                        "description": "Deleted the specified compute endpoint",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2589,6 +3228,9 @@
                             }
                         }
                     },
+                    "204": {
+                        "description": "Returned if the endpoint doesn't exist or has already been deleted"
+                    },
                     "default": {
                         "$ref": "#/components/responses/GeneralError"
                     }
@@ -2598,8 +3240,8 @@
                 "tags": [
                     "Endpoint"
                 ],
-                "summary": "Update an endpoint",
-                "description": "Updates the specified endpoint. Currently, only changing the associated branch is supported.\nThe branch that you specify cannot have an existing endpoint.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` and `branch_id` by listing your project's endpoints.\nAn `endpoint_id` has an `ep-` prefix. A `branch_id` has a `br-` prefix.\nFor more information about endpoints, see [Manage endpoints](https://neon.tech/docs/manage/endpoints/).\n\nIf the returned list of operations is not empty, the endpoint is not ready to use.\nThe client must wait for the last operation to finish before using the endpoint.\nIf the endpoint was idle before the update, the endpoint becomes active for a short period of time,\nand the control plane suspends it again after the update.\n",
+                "summary": "Update a compute endpoint",
+                "description": "Updates the specified compute endpoint.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` and `branch_id` by listing your project's compute endpoints.\nAn `endpoint_id` has an `ep-` prefix. A `branch_id` has a `br-` prefix.\n For more information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n\nIf the returned list of operations is not empty, the compute endpoint is not ready to use.\nThe client must wait for the last operation to finish before using the compute endpoint.\nIf the compute endpoint was idle before the update, it becomes active for a short period of time,\nand the control plane suspends it again after the update.\n",
                 "operationId": "updateProjectEndpoint",
                 "requestBody": {
                     "required": true,
@@ -2610,7 +3252,7 @@
                             },
                             "example": {
                                 "endpoint": {
-                                    "branch_id": "br-tiny-grass-283160"
+                                    "suspend_timeout_seconds": 300
                                 }
                             }
                         }
@@ -2618,7 +3260,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Updated the specified endpoint",
+                        "description": "Updated the specified compute endpoint",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2688,8 +3330,8 @@
         },
         "/projects/{project_id}/endpoints/{endpoint_id}/start": {
             "post": {
-                "summary": "Start an endpoint",
-                "description": "Starts an endpoint. The endpoint is ready to use\nafter the last operation in chain finishes successfully.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor more information about endpoints, see [Manage endpoints](https://neon.tech/docs/manage/endpoints/).\n",
+                "summary": "Start a compute endpoint",
+                "description": "Starts a compute endpoint. The compute endpoint is ready to use\nafter the last operation in chain finishes successfully.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's compute endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
                 "tags": [
                     "Endpoint"
                 ],
@@ -2701,7 +3343,8 @@
                         "description": "The Neon project ID",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
                         }
                     },
                     {
@@ -2710,13 +3353,14 @@
                         "description": "The endpoint ID",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
                         }
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Started the specified endpoint",
+                        "description": "Started the specified compute endpoint",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2780,7 +3424,8 @@
                     "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
@@ -2789,13 +3434,14 @@
                     "description": "The endpoint ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 }
             ],
             "post": {
-                "summary": "Suspend an endpoint",
-                "description": "Suspend the specified endpoint\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor more information about endpoints, see [Manage endpoints](https://neon.tech/docs/manage/endpoints/).\n",
+                "summary": "Suspend a compute endpoint",
+                "description": "Suspend the specified compute endpoint\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's compute endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
                 "tags": [
                     "Endpoint"
                 ],
@@ -2858,34 +3504,227 @@
                 }
             }
         },
-        "/projects/{project_id}/endpoints/{endpoint_id}/passwordless_auth": {
+        "/projects/{project_id}/endpoints/{endpoint_id}/restart": {
             "parameters": [
                 {
                     "name": "project_id",
                     "in": "path",
+                    "description": "The Neon project ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 {
                     "name": "endpoint_id",
                     "in": "path",
+                    "description": "The endpoint ID",
                     "required": true,
                     "schema": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 }
-            ]
-        },
-        "/consumption/projects": {
-            "get": {
-                "summary": "Retrieves a list consumption metrics for each project",
-                "description": "Retrieves a list consumption metrics for each project for the current billing period.\n**Important:** This is a preview API and may be subject to changes.\n",
+            ],
+            "post": {
+                "summary": "Restart a compute endpoint",
+                "description": "Restart the specified compute endpoint: suspend immediately followed by start operations.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's compute endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
                 "tags": [
-                    "Preview"
+                    "Endpoint"
                 ],
-                "operationId": "listProjectsConsumption",
+                "operationId": "restartProjectEndpoint",
+                "responses": {
+                    "200": {
+                        "description": "Restarted endpoint",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EndpointOperations"
+                                },
+                                "example": {
+                                    "endpoint": {
+                                        "host": "ep-steep-bush-777093.us-east-2.aws.neon.tech",
+                                        "id": "ep-steep-bush-777093",
+                                        "project_id": "shiny-wind-028834",
+                                        "branch_id": "br-raspy-hill-832856",
+                                        "autoscaling_limit_min_cu": 1,
+                                        "autoscaling_limit_max_cu": 1,
+                                        "region_id": "aws-us-east-2",
+                                        "type": "read_write",
+                                        "current_state": "idle",
+                                        "settings": {
+                                            "pg_settings": {}
+                                        },
+                                        "pooler_enabled": false,
+                                        "pooler_mode": "transaction",
+                                        "disabled": false,
+                                        "passwordless_access": true,
+                                        "last_active": "2022-12-03T15:00:00Z",
+                                        "created_at": "2022-12-03T15:37:07Z",
+                                        "updated_at": "2022-12-03T15:49:10Z",
+                                        "proxy_host": "us-east-2.aws.neon.tech",
+                                        "creation_source": "console",
+                                        "provisioner": "k8s-pod",
+                                        "suspend_timeout_seconds": 10800
+                                    },
+                                    "operations": [
+                                        {
+                                            "id": "e061087e-3c99-4856-b9c8-6b7751a253af",
+                                            "project_id": "bitter-meadow-966132",
+                                            "branch_id": "br-proud-paper-090813",
+                                            "endpoint_id": "ep-shrill-thunder-454069",
+                                            "action": "suspend_compute",
+                                            "status": "running",
+                                            "failures_count": 0,
+                                            "created_at": "2022-12-03T15:51:06Z",
+                                            "updated_at": "2022-12-03T15:51:06Z",
+                                            "total_duration_ms": 100
+                                        },
+                                        {
+                                            "id": "e061087e-3c99-4856-b9c8-6b7751a253af",
+                                            "project_id": "bitter-meadow-966132",
+                                            "branch_id": "br-proud-paper-090813",
+                                            "endpoint_id": "ep-shrill-thunder-454069",
+                                            "action": "start_compute",
+                                            "status": "running",
+                                            "failures_count": 0,
+                                            "created_at": "2022-12-03T15:51:06Z",
+                                            "updated_at": "2022-12-03T15:51:06Z",
+                                            "total_duration_ms": 100
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/consumption_history/account": {
+            "get": {
+                "summary": "Get account consumption metrics",
+                "description": "Retrieves consumption metrics for Scale and Business plan accounts. History begins at the time of upgrade.\nAvailable for Scale and Business plan users only.\n",
+                "tags": [
+                    "Consumption"
+                ],
+                "operationId": "getConsumptionHistoryPerAccount",
+                "parameters": [
+                    {
+                        "name": "from",
+                        "description": "Specify the start `date-time` for the consumption period.\nThe `date-time` value is rounded according to the specified `granularity`.\nFor example, `2024-03-15T15:30:00Z` for `daily` granularity will be rounded to `2024-03-15T00:00:00Z`.\nThe specified `date-time` value must respect the specified granularity:\n- For `hourly`, consumption metrics are limited to the last 168 hours.\n- For `daily`, consumption metrics are limited to the last 60 days.\n- For `monthly`, consumption metrics are limited to the past year.\n\nThe consumption history is available starting from `March 1, 2024, at 00:00:00 UTC`.\n",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "required": true
+                    },
+                    {
+                        "name": "to",
+                        "description": "Specify the end `date-time` for the consumption period.\nThe `date-time` value is rounded according to the specified granularity.\nFor example, `2024-03-15T15:30:00Z` for `daily` granularity will be rounded to `2024-03-15T00:00:00Z`.\nThe specified `date-time` value must respect the specified granularity:\n- For `hourly`, consumption metrics are limited to the last 168 hours.\n- For `daily`, consumption metrics are limited to the last 60 days.\n- For `monthly`, consumption metrics are limited to the past year.\n",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "required": true
+                    },
+                    {
+                        "name": "granularity",
+                        "description": "Specify the granularity of consumption metrics.\nHourly, daily, and monthly metrics are available for the last 168 hours, 60 days,\nand 1 year, respectively.\n",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/ConsumptionHistoryGranularity"
+                        },
+                        "required": true
+                    },
+                    {
+                        "name": "org_id",
+                        "description": "Specify the organization for which the consumption metrics should be returned.\nIf this parameter is not provided, the endpoint will return the metrics for the\nauthenticated user's account.\n",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        }
+                    },
+                    {
+                        "name": "include_v1_metrics",
+                        "description": "Include metrics utilized in previous pricing models.\n- **data_storage_bytes_hour**: The sum of the maximum observed storage values for each hour\n  for each project, which never decreases.\n",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returned consumption metrics for the Neon account",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConsumptionHistoryPerAccountResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "This endpoint is not available. It is only supported for Scale and Business plan accounts.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeneralError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Account is not a member of the organization specified by `org_id`.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeneralError"
+                                }
+                            }
+                        }
+                    },
+                    "406": {
+                        "description": "The specified `date-time` range is outside the boundaries of the specified `granularity`.\nAdjust your `from` and `to` values or select a different `granularity`.\n",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeneralError"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "Too many requests",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeneralError"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/consumption_history/projects": {
+            "get": {
+                "summary": "Get consumption metrics for each project",
+                "description": "Retrieves consumption metrics for Scale and Business plan projects. History begins at the time of upgrade.\nAvailable for Scale and Business plan users only.\nIssuing a call to this API does not wake a project's compute endpoint.\n",
+                "tags": [
+                    "Consumption"
+                ],
+                "operationId": "getConsumptionHistoryPerProject",
                 "parameters": [
                     {
                         "name": "cursor",
@@ -2897,48 +3736,787 @@
                     },
                     {
                         "name": "limit",
-                        "description": "Specify a value from 1 to 1000 to limit number of projects in the response.",
+                        "description": "Specify a value from 1 to 100 to limit number of projects in the response.",
                         "in": "query",
                         "schema": {
                             "type": "integer",
                             "minimum": 1,
                             "default": 10,
-                            "maximum": 1000
+                            "maximum": 100
+                        }
+                    },
+                    {
+                        "name": "project_ids",
+                        "description": "Specify a list of project IDs to filter the response.\nIf omitted, the response will contain all projects.\nA list of project IDs can be specified as an array of parameter values or as a comma-separated list in a single parameter value.\n- As an array of parameter values: `project_ids=cold-poetry-09157238%20&project_ids=quiet-snow-71788278`\n- As a comma-separated list in a single parameter value: `project_ids=cold-poetry-09157238,quiet-snow-71788278`\n",
+                        "in": "query",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "pattern": "^([a-z0-9-]{1,60}(,[a-z0-9-]{1,60}){0,99})?$",
+                                "type": "string"
+                            },
+                            "minItems": 0,
+                            "maxItems": 100
                         }
                     },
                     {
                         "name": "from",
-                        "description": "Specify the start date-time for the consumption period.\nIf `from` or `to` is not specified, we return only current consumption period.\n",
+                        "description": "Specify the start `date-time` for the consumption period.\nThe `date-time` value is rounded according to the specified `granularity`.\nFor example, `2024-03-15T15:30:00Z` for `daily` granularity will be rounded to `2024-03-15T00:00:00Z`.\nThe specified `date-time` value must respect the specified `granularity`:\n- For `hourly`, consumption metrics are limited to the last 168 hours.\n- For `daily`, consumption metrics are limited to the last 60 days.\n- For `monthly`, consumption metrics are limited to the last year.\n\nThe consumption history is available starting from `March 1, 2024, at 00:00:00 UTC`.\n",
                         "in": "query",
                         "schema": {
                             "type": "string",
                             "format": "date-time"
-                        }
+                        },
+                        "required": true
                     },
                     {
                         "name": "to",
-                        "description": "Specify the end date-time period for the consumption period.\nIf `from` or `to` is not specified, only the current consumption period is returned.\n",
+                        "description": "Specify the end `date-time` for the consumption period.\nThe `date-time` value is rounded according to the specified granularity.\nFor example, `2024-03-15T15:30:00Z` for `daily` granularity will be rounded to `2024-03-15T00:00:00Z`.\nThe specified `date-time` value must respect the specified `granularity`:\n- For `hourly`, consumption metrics are limited to the last 168 hours.\n- For `daily`, consumption metrics are limited to the last 60 days.\n- For `monthly`, consumption metrics are limited to the last year.\n",
                         "in": "query",
                         "schema": {
                             "type": "string",
                             "format": "date-time"
+                        },
+                        "required": true
+                    },
+                    {
+                        "name": "granularity",
+                        "description": "Specify the granularity of consumption metrics.\nHourly, daily, and monthly metrics are available for the last 168 hours, 60 days,\nand 1 year, respectively.\n",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/ConsumptionHistoryGranularity"
+                        },
+                        "required": true
+                    },
+                    {
+                        "name": "org_id",
+                        "description": "Specify the organization for which the project consumption metrics should be returned.\nIf this parameter is not provided, the endpoint will return the metrics for the\nauthenticated user's projects.\n",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        }
+                    },
+                    {
+                        "name": "include_v1_metrics",
+                        "description": "Include metrics utilized in previous pricing models.\n- **data_storage_bytes_hour**: The sum of the maximum observed storage values for each hour,\n  which never decreases.\n",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean"
                         }
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Returned a list of project consumption metrics for the Neon account",
+                        "description": "Returned project consumption metrics for the Neon account",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "allOf": [
                                         {
-                                            "$ref": "#/components/schemas/ProjectsConsumptionResponse"
+                                            "$ref": "#/components/schemas/ConsumptionHistoryPerProjectResponse"
                                         },
                                         {
                                             "$ref": "#/components/schemas/PaginationResponse"
                                         }
                                     ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "This endpoint is not available. It is only supported with Scale and Business plan accounts.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeneralError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Account is not a member of the organization specified by `org_id`.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeneralError"
+                                }
+                            }
+                        }
+                    },
+                    "406": {
+                        "description": "The specified `date-time` range is outside the boundaries of the specified `granularity`.\nAdjust your `from` and `to` values or select a different `granularity`.\n",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeneralError"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "Too many requests",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeneralError"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/organizations/{org_id}": {
+            "parameters": [
+                {
+                    "name": "org_id",
+                    "in": "path",
+                    "description": "The Neon organization ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Get organization details",
+                "description": "Retrieves information about the specified organization.\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "getOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Returned information about the organization",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Organization"
+                                },
+                                "example": {
+                                    "id": "my-organization-morning-bread-81040908",
+                                    "name": "my-organization",
+                                    "handle": "my-organization-my-organization-morning-bread-81040908",
+                                    "plan": "scale",
+                                    "managed_by": "console",
+                                    "created_at": "2024-02-23T17:42:25Z",
+                                    "updated_at": "2024-02-26T20:41:25Z"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/organizations/{org_id}/api_keys": {
+            "parameters": [
+                {
+                    "name": "org_id",
+                    "in": "path",
+                    "description": "The Neon organization ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Get a list of organization API keys",
+                "description": "Retrieves the API keys for the specified organization.\nThe response does not include API key tokens. A token is only provided when creating an API key.\nAPI keys can also be managed in the Neon Console.\nFor more information, see [Manage API keys](https://neon.tech/docs/manage/api-keys/).\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "listOrgApiKeys",
+                "responses": {
+                    "200": {
+                        "description": "Returned the API keys for the specified organization",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/OrgApiKeysListResponseItem"
+                                    },
+                                    "example": [
+                                        {
+                                            "id": 165432,
+                                            "name": "orgkey_1",
+                                            "created_at": "2022-11-15T20:13:35Z",
+                                            "created_by": {
+                                                "id": "629982cc-de05-43db-ae16-28f2399c4910",
+                                                "name": "John Smith",
+                                                "image": "http://link.to.image"
+                                            },
+                                            "last_used_at": "2022-11-15T20:22:51Z",
+                                            "last_used_from_addr": "192.0.2.255"
+                                        },
+                                        {
+                                            "id": 165433,
+                                            "name": "orgkey_2",
+                                            "created_at": "2022-11-15T20:12:36Z",
+                                            "created_by": {
+                                                "id": "629982cc-de05-43db-ae16-28f2399c4910",
+                                                "name": "John Smith",
+                                                "image": "http://link.to.image"
+                                            },
+                                            "last_used_at": "2022-11-15T20:15:04Z",
+                                            "last_used_from_addr": "192.0.2.255"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            },
+            "post": {
+                "summary": "Create an organization API key",
+                "description": "Creates an API key for the specified organization.\nThe `key_name` is a user-specified name for the key.\nThis method returns an `id` and `key`. The `key` is a randomly generated, 64-bit token required to access the Neon API.\nAPI keys can also be managed in the Neon Console.\nSee [Manage API keys](https://neon.tech/docs/manage/api-keys/).\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "createOrgApiKey",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OrgApiKeyCreateRequest"
+                            },
+                            "example": {
+                                "key_name": "orgkey"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Created an organization API key",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrgApiKeyCreateResponse"
+                                },
+                                "example": {
+                                    "id": 165434,
+                                    "key": "9v1faketcjbl4sn1013keyd43n2a8qlfakeog8yvp40hx16keyjo1bpds4y2dfms3",
+                                    "name": "orgkey",
+                                    "created_at": "2022-11-15T20:13:35Z",
+                                    "created_by": "629982cc-de05-43db-ae16-28f2399c4910"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/organizations/{org_id}/api_keys/{key_id}": {
+            "parameters": [
+                {
+                    "name": "org_id",
+                    "in": "path",
+                    "description": "The Neon organization ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    }
+                }
+            ],
+            "delete": {
+                "summary": "Revoke an organization API key",
+                "description": "Revokes the specified organization API key.\nAn API key that is no longer needed can be revoked.\nThis action cannot be reversed.\nYou can obtain `key_id` values by listing the API keys for an organization.\nAPI keys can also be managed in the Neon Console.\nSee [Manage API keys](https://neon.tech/docs/manage/api-keys/).\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "revokeOrgApiKey",
+                "parameters": [
+                    {
+                        "name": "key_id",
+                        "in": "path",
+                        "description": "The API key ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Revoked the specified organization API key",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrgApiKeyRevokeResponse"
+                                },
+                                "example": {
+                                    "id": 165435,
+                                    "name": "orgkey",
+                                    "created_at": "2022-11-15T20:13:35Z",
+                                    "created_by": "629982cc-de05-43db-ae16-28f2399c4910",
+                                    "last_used_at": "2022-11-15T20:15:04Z",
+                                    "last_used_from_addr": "192.0.2.255",
+                                    "revoked": true
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/organizations/{org_id}/members": {
+            "parameters": [
+                {
+                    "name": "org_id",
+                    "in": "path",
+                    "description": "The Neon organization ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Get organization members details",
+                "description": "Retrieves information about the specified organization members.\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "getOrganizationMembers",
+                "responses": {
+                    "200": {
+                        "description": "Returned information about organization members",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationMembersResponse"
+                                },
+                                "example": {
+                                    "members": [
+                                        {
+                                            "member": {
+                                                "id": "d57833f2-d308-4ede-9d2e-468d9d013d1b",
+                                                "user_id": "b107d689-6dd2-4c9a-8b9e-0b25e457cf56",
+                                                "org_id": "my-organization-morning-bread-81040908",
+                                                "role": "admin",
+                                                "joined_at": "2024-02-23T17:42:25Z"
+                                            },
+                                            "user": {
+                                                "email": "user1@email.com"
+                                            }
+                                        },
+                                        {
+                                            "member": {
+                                                "id": "5fee13ac-957b-40cd-8de0-4d494cc28e28",
+                                                "user_id": "6df052ac-ca9a-4321-8963-b6507b2d7dee",
+                                                "org_id": "my-organization-morning-bread-81040908",
+                                                "role": "member",
+                                                "joined_at": "2024-02-21T16:42:25Z"
+                                            },
+                                            "user": {
+                                                "email": "user2@email.com"
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/organizations/{org_id}/members/{member_id}": {
+            "parameters": [
+                {
+                    "name": "org_id",
+                    "in": "path",
+                    "description": "The Neon organization ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    }
+                },
+                {
+                    "name": "member_id",
+                    "in": "path",
+                    "description": "The Neon organization member ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Get organization member details",
+                "description": "Retrieves information about the specified organization member.\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "getOrganizationMember",
+                "responses": {
+                    "200": {
+                        "description": "Returned information about the organization member",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Member"
+                                },
+                                "example": {
+                                    "id": "d57833f2-d308-4ede-9d2e-468d9d013d1b",
+                                    "user_id": "b107d689-6dd2-4c9a-8b9e-0b25e457cf56",
+                                    "org_id": "my-organization-morning-bread-81040908",
+                                    "role": "admin",
+                                    "joined_at": "2024-02-23T17:42:25Z"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            },
+            "patch": {
+                "summary": "Update the role for an organization member",
+                "description": "Only an admin can perform this action.\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "updateOrganizationMember",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OrganizationMemberUpdateRequest"
+                            },
+                            "example": {
+                                "role": "admin"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "The updated organization member",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Member"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Remove member from the organization",
+                "description": "Remove member from the organization.\nOnly an admin of the organization can perform this action.\nIf another admin is being removed, it will not be allows in case it is the only admin left in the organization.\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "removeOrganizationMember",
+                "responses": {
+                    "200": {
+                        "description": "Removed organization member",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EmptyResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/organizations/{org_id}/invitations": {
+            "parameters": [
+                {
+                    "name": "org_id",
+                    "in": "path",
+                    "description": "The Neon organization ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Get organization invitation details",
+                "description": "Retrieves information about extended invitations for the specified organization\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "getOrganizationInvitations",
+                "responses": {
+                    "200": {
+                        "description": "Returned information about the organization invitations",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationInvitationsResponse"
+                                },
+                                "example": {
+                                    "invitations": [
+                                        {
+                                            "id": "db8faf32-b07f-4b0f-94c8-5c288909f5d3",
+                                            "email": "invited1@email.com",
+                                            "org_id": "my-organization-morning-bread-81040908",
+                                            "invited_by": "some@email.com",
+                                            "role": "admin",
+                                            "invited_at": "2024-02-23T17:42:25Z"
+                                        },
+                                        {
+                                            "id": "c52f0d22-ebd9-4708-ae44-2872cae49a83",
+                                            "email": "invited2@email.com",
+                                            "org_id": "my-organization-morning-bread-81040908",
+                                            "invited_by": "some@email.com",
+                                            "role": "member",
+                                            "invited_at": "2024-02-23T12:42:25Z"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            },
+            "post": {
+                "summary": "Create organization invitations",
+                "description": "Creates invitations for a specific organization.\nIf the invited user has an existing account, they automatically join as a member.\nIf they don't yet have an account, they are invited to create one, after which they become a member.\nEach invited user receives an email notification.\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "createOrganizationInvitations",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OrganizationInvitesCreateRequest"
+                            },
+                            "example": {
+                                "invitations": [
+                                    {
+                                        "email": "invited-user@email.com",
+                                        "role": "member"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "The created organization invitation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationInvitationsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/organizations/{org_id}/vpc/region/{region_id}/vpc_endpoints": {
+            "parameters": [
+                {
+                    "name": "org_id",
+                    "in": "path",
+                    "description": "The Neon organization ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    }
+                },
+                {
+                    "name": "region_id",
+                    "in": "path",
+                    "description": "The Neon region ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Get the list of VPC endpoints",
+                "description": "Retrieves the list of VPC endpoints for the specified organization.\nThis endpoint is under active development and its semantics may change in the future.\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "listOrganizationVPCEndpoints",
+                "responses": {
+                    "200": {
+                        "description": "The list of configured VPC endpoint IDs for the specified organization",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VPCEndpointsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/organizations/{org_id}/vpc/region/{region_id}/vpc_endpoints/{vpc_endpoint_id}": {
+            "parameters": [
+                {
+                    "name": "org_id",
+                    "in": "path",
+                    "description": "The Neon organization ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    }
+                },
+                {
+                    "name": "region_id",
+                    "in": "path",
+                    "description": "The Neon region ID.\nNote that Azure regions are not yet supported.\n",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "name": "vpc_endpoint_id",
+                    "in": "path",
+                    "description": "The VPC endpoint ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Retrieve the state of a VPC endpoint configuration",
+                "description": "Retrieves detailed information about the VPC endpoint.\nThis endpoint is under active development and its semantics may change in the future.\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "getOrganizationVPCEndpointDetails",
+                "responses": {
+                    "200": {
+                        "description": "The detailed state of the VPC endpoint",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VPCEndpointDetails"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            },
+            "post": {
+                "summary": "Assign or update a VPC endpoint",
+                "description": "Assigns the specified VPC endpoint to the specified organization\nor updates the existing assignment.\nThis endpoint is under active development and its semantics may change in the future.\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "assignOrganizationVPCEndpoint",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/VPCEndpointAssignment"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Assigned the specified VPC endpoint to the specified organization"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete a VPC endpoint",
+                "description": "Deletes the specified VPC endpoint from the specified organization.\nThis endpoint is under active development and its semantics may change in the future.\n",
+                "tags": [
+                    "Organizations"
+                ],
+                "operationId": "deleteOrganizationVPCEndpoint",
+                "responses": {
+                    "200": {
+                        "description": "Deleted the specified VPC endpoint from the specified organization"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/regions": {
+            "get": {
+                "summary": "Get current active regions",
+                "description": "Retrieves the list of supported Neon regions\n",
+                "tags": [
+                    "Region"
+                ],
+                "operationId": "getActiveRegions",
+                "responses": {
+                    "200": {
+                        "description": "The list of active regions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ActiveRegionsResponse"
                                 }
                             }
                         }
@@ -2964,6 +4542,94 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/CurrentUserInfoResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/users/me/organizations": {
+            "get": {
+                "summary": "Get current user organizations list",
+                "description": "Retrieves information about the current Neon user's organizations\n",
+                "operationId": "getCurrentUserOrganizations",
+                "tags": [
+                    "Users",
+                    "Organizations"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returned information about the current user organizations\n",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/GeneralError"
+                    }
+                }
+            }
+        },
+        "/users/me/projects/transfer": {
+            "post": {
+                "summary": "Transfer projects from your personal account to a specified destination account",
+                "description": "Transfers selected projects, identified by their IDs, from your personal account to a specified organization.\n",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TransferProjectsToOrganizationRequest"
+                            }
+                        }
+                    }
+                },
+                "tags": [
+                    "Users"
+                ],
+                "operationId": "transferProjectsFromUserToOrg",
+                "responses": {
+                    "200": {
+                        "description": "Projects successfully transferred from personal account to organization",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EmptyResponse"
+                                }
+                            }
+                        }
+                    },
+                    "406": {
+                        "description": "Transfer failed - the organization has too many projects or its plan is incompatible with the source account. Reduce projects or upgrade the organization.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/LimitsUnsatisfiedResponse"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/GeneralError"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "One or more of project ids provided is linked by GitHub or Vercel integration. Transferring integration projects is currently not supported",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProjectsWithIntegrationResponse"
                                 }
                             }
                         }
@@ -3086,20 +4752,40 @@
                 "type": "apiKey",
                 "in": "cookie",
                 "name": "zenith"
+            },
+            "TokenCookieAuth": {
+                "type": "apiKey",
+                "in": "cookie",
+                "name": "keycloak_token"
             }
         },
         "schemas": {
+            "Features": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "boolean"
+                }
+            },
+            "FeatureFlags": {
+                "type": "object",
+                "additionalProperties": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
             "ComputeUnit": {
                 "type": "number",
                 "minimum": 0.25
             },
             "Provisioner": {
                 "type": "string",
-                "description": "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n",
-                "enum": [
-                    "k8s-pod",
-                    "k8s-neonvm"
-                ]
+                "description": "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n\nProvisioner can be one of the following values:\n* k8s-pod\n* k8s-neonvm\n\nClients must expect, that any string value that is not documented in the description above should be treated as a error. UNKNOWN value if safe to treat as an error too.\n"
             },
             "PaginationResponse": {
                 "type": "object",
@@ -3131,6 +4817,107 @@
                 "description": "Empty response.",
                 "properties": {}
             },
+            "AddProjectJWKSRequest": {
+                "description": "Add a new JWKS to a specific endpoint of a project",
+                "type": "object",
+                "required": [
+                    "jwks_url",
+                    "provider_name",
+                    "role_names"
+                ],
+                "properties": {
+                    "jwks_url": {
+                        "description": "The URL that lists the JWKS",
+                        "type": "string"
+                    },
+                    "provider_name": {
+                        "description": "The name of the authentication provider (e.g., Clerk, Stytch, Auth0)",
+                        "type": "string"
+                    },
+                    "branch_id": {
+                        "description": "Branch ID",
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    },
+                    "jwt_audience": {
+                        "description": "The name of the required JWT Audience to be used",
+                        "type": "string"
+                    },
+                    "role_names": {
+                        "description": "The roles the JWKS should be mapped to",
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 10,
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "JWKS": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "project_id",
+                    "jwks_url",
+                    "provider_name",
+                    "created_at",
+                    "updated_at"
+                ],
+                "properties": {
+                    "id": {
+                        "description": "JWKS ID",
+                        "type": "string"
+                    },
+                    "project_id": {
+                        "description": "Project ID",
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    },
+                    "branch_id": {
+                        "description": "Branch ID",
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    },
+                    "jwks_url": {
+                        "description": "The URL that lists the JWKS",
+                        "type": "string"
+                    },
+                    "provider_name": {
+                        "description": "The name of the authentication provider (e.g., Clerk, Stytch, Auth0)",
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "description": "The date and time when the JWKS was created",
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "description": "The date and time when the JWKS was last modified",
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "jwt_audience": {
+                        "description": "The name of the required JWT Audience to be used",
+                        "type": "string"
+                    }
+                }
+            },
+            "ProjectJWKSResponse": {
+                "description": "The list of configured JWKS definitions for a project",
+                "type": "object",
+                "required": [
+                    "jwks"
+                ],
+                "properties": {
+                    "jwks": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JWKS"
+                        }
+                    }
+                }
+            },
             "ApiKeyCreateRequest": {
                 "type": "object",
                 "required": [
@@ -3139,9 +4926,27 @@
                 "properties": {
                     "key_name": {
                         "type": "string",
-                        "description": "A user-specified API key name. This value is required when creating an API key."
+                        "description": "A user-specified API key name. This value is required when creating an API key.",
+                        "maxLength": 64
                     }
                 }
+            },
+            "OrgApiKeyCreateRequest": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ApiKeyCreateRequest"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "project_id": {
+                                "description": "If set, the API key can access only this project",
+                                "type": "string",
+                                "pattern": "^[a-z0-9-]{1,60}$"
+                            }
+                        }
+                    }
+                ]
             },
             "ApiKeyCreateResponse": {
                 "type": "object",
@@ -3149,7 +4954,8 @@
                     "key",
                     "id",
                     "name",
-                    "created_at"
+                    "created_at",
+                    "created_by"
                 ],
                 "properties": {
                     "id": {
@@ -3169,50 +4975,40 @@
                         "description": "A timestamp indicating when the API key was created",
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "created_by": {
+                        "description": "ID of the user who created this API key",
+                        "type": "string",
+                        "format": "uuid"
                     }
                 }
+            },
+            "OrgApiKeyCreateResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ApiKeyCreateResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "project_id": {
+                                "description": "If set, the API key can access only this project",
+                                "type": "string",
+                                "pattern": "^[a-z0-9-]{1,60}$"
+                            }
+                        }
+                    }
+                ]
             },
             "ApiKeyRevokeResponse": {
                 "type": "object",
                 "required": [
                     "id",
                     "name",
-                    "revoked",
-                    "last_used_from_addr"
-                ],
-                "properties": {
-                    "id": {
-                        "description": "The API key ID",
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "name": {
-                        "description": "The user-specified API key name",
-                        "type": "string"
-                    },
-                    "revoked": {
-                        "description": "A `true` or `false` value indicating whether the API key is revoked",
-                        "type": "boolean"
-                    },
-                    "last_used_at": {
-                        "description": "A timestamp indicating when the API was last used",
-                        "type": "string",
-                        "format": "date-time",
-                        "nullable": true
-                    },
-                    "last_used_from_addr": {
-                        "description": "The IP address from which the API key was last used",
-                        "type": "string"
-                    }
-                }
-            },
-            "ApiKeysListResponseItem": {
-                "type": "object",
-                "required": [
+                    "created_at",
+                    "created_by",
                     "last_used_from_addr",
-                    "id",
-                    "name",
-                    "created_at"
+                    "revoked"
                 ],
                 "properties": {
                     "id": {
@@ -3229,6 +5025,11 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "created_by": {
+                        "description": "ID of the user who created this API key",
+                        "type": "string",
+                        "format": "uuid"
+                    },
                     "last_used_at": {
                         "description": "A timestamp indicating when the API was last used",
                         "type": "string",
@@ -3238,6 +5039,107 @@
                     "last_used_from_addr": {
                         "description": "The IP address from which the API key was last used",
                         "type": "string"
+                    },
+                    "revoked": {
+                        "description": "A `true` or `false` value indicating whether the API key is revoked",
+                        "type": "boolean"
+                    }
+                }
+            },
+            "OrgApiKeyRevokeResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ApiKeyRevokeResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "project_id": {
+                                "description": "If set, the API key can access only this project",
+                                "type": "string",
+                                "pattern": "^[a-z0-9-]{1,60}$"
+                            }
+                        }
+                    }
+                ]
+            },
+            "ApiKeysListResponseItem": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "name",
+                    "created_at",
+                    "created_by",
+                    "last_used_from_addr"
+                ],
+                "properties": {
+                    "id": {
+                        "description": "The API key ID",
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "description": "The user-specified API key name",
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "description": "A timestamp indicating when the API key was created",
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "created_by": {
+                        "$ref": "#/components/schemas/ApiKeyCreatorData"
+                    },
+                    "last_used_at": {
+                        "description": "A timestamp indicating when the API was last used",
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "last_used_from_addr": {
+                        "description": "The IP address from which the API key was last used",
+                        "type": "string"
+                    }
+                }
+            },
+            "OrgApiKeysListResponseItem": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ApiKeysListResponseItem"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "project_id": {
+                                "description": "If set, the API key can access only this project",
+                                "type": "string",
+                                "pattern": "^[a-z0-9-]{1,60}$"
+                            }
+                        }
+                    }
+                ]
+            },
+            "ApiKeyCreatorData": {
+                "description": "The user data of the user that created this API key.",
+                "type": "object",
+                "required": [
+                    "id",
+                    "name",
+                    "image"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "ID of the user who created this API key"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the user."
+                    },
+                    "image": {
+                        "type": "string",
+                        "description": "The URL to the user's avatar image."
                     }
                 }
             },
@@ -3261,15 +5163,18 @@
                     },
                     "project_id": {
                         "description": "The Neon project ID",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
                     "branch_id": {
                         "description": "The branch ID",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
                     "endpoint_id": {
                         "description": "The endpoint ID",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
                     "action": {
                         "$ref": "#/components/schemas/OperationAction"
@@ -3377,17 +5282,28 @@
                     "tenant_reattach",
                     "replace_safekeeper",
                     "disable_maintenance",
-                    "apply_storage_config"
+                    "apply_storage_config",
+                    "prepare_secondary_pageserver",
+                    "switch_pageserver",
+                    "detach_parent_branch",
+                    "timeline_archive",
+                    "timeline_unarchive",
+                    "start_reserved_compute",
+                    "sync_dbs_and_roles_from_compute"
                 ]
             },
             "OperationStatus": {
                 "description": "The status of the operation",
                 "type": "string",
                 "enum": [
+                    "scheduling",
                     "running",
                     "finished",
                     "failed",
-                    "scheduling"
+                    "error",
+                    "cancelling",
+                    "cancelled",
+                    "skipped"
                 ]
             },
             "ProjectListItem": {
@@ -3413,8 +5329,9 @@
                 ],
                 "properties": {
                     "id": {
-                        "description": "The project ID\n",
-                        "type": "string"
+                        "description": "The project ID",
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
                     "platform_id": {
                         "description": "The cloud platform identifier. Currently, only AWS is supported, for which the identifier is `aws`.\n",
@@ -3507,6 +5424,11 @@
                         "description": "The most recent time when any endpoint of this project was active.\n\nOmitted when observed no actitivy for endpoints of this project.\n",
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "org_id": {
+                        "description": "Organization id if a project belongs to organization.\nPermissions for the project will be given to organization members as defined by the organization admins.\nThe permissions of the project do not depend on the user that created the project if a project belongs to an organization.\n",
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 "example": {
@@ -3588,8 +5510,9 @@
                         "deprecated": true
                     },
                     "id": {
-                        "description": "The project ID\n",
-                        "type": "string"
+                        "description": "The project ID",
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
                     "platform_id": {
                         "description": "The cloud platform identifier. Currently, only AWS is supported, for which the identifier is `aws`.\n",
@@ -3643,9 +5566,9 @@
                         "type": "string"
                     },
                     "history_retention_seconds": {
-                        "description": "The number of seconds to retain point-in-time restore (PITR) backup history for this project.\n",
+                        "description": "The number of seconds to retain the shared history for all branches in this project. The default for all plans is 1 day (86400 seconds).\n",
                         "type": "integer",
-                        "format": "int64"
+                        "format": "int32"
                     },
                     "created_at": {
                         "description": "A timestamp indicating when the project was created\n",
@@ -3688,6 +5611,10 @@
                         "description": "The most recent time when any endpoint of this project was active.\n\nOmitted when observed no actitivy for endpoints of this project.\n",
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "org_id": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     }
                 },
                 "example": {
@@ -3704,10 +5631,12 @@
                     "created_at": "2022-12-13T01:30:55Z",
                     "updated_at": "2022-12-13T01:30:55Z",
                     "owner": {
+                        "name": "John Smith",
                         "email": "some@email.com",
                         "branches_limit": 10,
-                        "subscription_type": "pro"
-                    }
+                        "subscription_type": "scale"
+                    },
+                    "org_id": "org-morning-bread-81040908"
                 }
             },
             "ProjectCreateRequest": {
@@ -3730,15 +5659,15 @@
                                 "type": "object",
                                 "properties": {
                                     "name": {
-                                        "description": "The branch name. If not specified, the default branch name will be used.\n",
+                                        "description": "The default branch name. If not specified, the default branch name, `main`, will be used.\n",
                                         "type": "string"
                                     },
                                     "role_name": {
-                                        "description": "The role name. If not specified, the default role name will be used.\n",
+                                        "description": "The role name. If not specified, the default role name, `{database_name}_owner`, will be used.\n",
                                         "type": "string"
                                     },
                                     "database_name": {
-                                        "description": "The database name. If not specified, the default database name will be used.\n",
+                                        "description": "The database name. If not specified, the default database name, `neondb`, will be used.\n",
                                         "type": "string"
                                     }
                                 }
@@ -3771,11 +5700,16 @@
                                 "type": "boolean"
                             },
                             "history_retention_seconds": {
-                                "description": "The number of seconds to retain the point-in-time restore (PITR) backup history for this project.\nThe default is 604800 seconds (7 days).\n",
+                                "description": "The number of seconds to retain the shared history for all branches in this project.\nThe default is 1 day (86400 seconds).\n",
                                 "type": "integer",
-                                "format": "int64",
+                                "format": "int32",
                                 "minimum": 0,
                                 "maximum": 2592000
+                            },
+                            "org_id": {
+                                "description": "Organization id in case the project created belongs to an organization.\nIf not present, project is owned by a user and not by org.\n",
+                                "type": "string",
+                                "pattern": "^[a-z0-9-]{1,60}$"
                             }
                         }
                     }
@@ -3801,9 +5735,9 @@
                                 "$ref": "#/components/schemas/DefaultEndpointSettings"
                             },
                             "history_retention_seconds": {
-                                "description": "The number of seconds to retain the point-in-time restore (PITR) backup history for this project.\nThe default is 604800 seconds (7 days).\n",
+                                "description": "The number of seconds to retain the shared history for all branches in this project.\nThe default is 1 day (604800 seconds).\n",
                                 "type": "integer",
-                                "format": "int64",
+                                "format": "int32",
                                 "minimum": 0,
                                 "maximum": 2592000
                             }
@@ -3822,6 +5756,17 @@
                     },
                     "enable_logical_replication": {
                         "description": "Sets wal_level=logical for all compute endpoints in this project.\nAll active endpoints will be suspended.\nOnce enabled, logical replication cannot be disabled.\n",
+                        "type": "boolean"
+                    },
+                    "maintenance_window": {
+                        "$ref": "#/components/schemas/MaintenanceWindow"
+                    },
+                    "block_public_connections": {
+                        "description": "When set, connections from the public internet\nare disallowed. This supersedes the AllowedIPs list.\nThis parameter is under active development and its semantics may change in the future.\n",
+                        "type": "boolean"
+                    },
+                    "block_vpc_connections": {
+                        "description": "When set, connections using VPC endpoints are disallowed.\nThis parameter is under active development and its semantics may change in the future.\n",
                         "type": "boolean"
                     }
                 }
@@ -3847,6 +5792,14 @@
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/ProjectListItem"
+                        }
+                    },
+                    "unavailable_project_ids": {
+                        "description": "A list of project IDs indicating which projects are known to exist, but whose details could not\nbe fetched within the requested (or implicit) time limit\n",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
                         }
                     }
                 }
@@ -3900,189 +5853,285 @@
                     }
                 }
             },
-            "ProjectsConsumptionResponse": {
+            "ConsumptionHistoryPerAccountResponse": {
                 "type": "object",
+                "properties": {
+                    "periods": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ConsumptionHistoryPerPeriod"
+                        }
+                    }
+                },
                 "required": [
-                    "projects",
-                    "periods_in_response"
-                ],
+                    "periods"
+                ]
+            },
+            "ConsumptionHistoryPerProjectResponse": {
+                "type": "object",
                 "properties": {
                     "projects": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/ProjectConsumption"
+                            "$ref": "#/components/schemas/ConsumptionHistoryPerProject"
                         }
-                    },
-                    "periods_in_response": {
-                        "type": "integer",
-                        "format": "int64"
                     }
-                }
-            },
-            "ProjectConsumption": {
-                "type": "object",
+                },
                 "required": [
-                    "period_id",
-                    "previous_period_id",
-                    "project_id",
-                    "active_time_seconds",
-                    "compute_time_seconds",
-                    "written_data_bytes",
-                    "data_transfer_bytes",
-                    "data_storage_bytes_hour",
-                    "synthetic_storage_size",
-                    "updated_at",
-                    "period_start",
-                    "period_end"
-                ],
+                    "projects"
+                ]
+            },
+            "ConsumptionHistoryPerProject": {
+                "type": "object",
                 "properties": {
                     "project_id": {
                         "description": "The project ID",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
+                    "periods": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ConsumptionHistoryPerPeriod"
+                        }
+                    }
+                },
+                "required": [
+                    "project_id",
+                    "periods"
+                ]
+            },
+            "ConsumptionHistoryPerPeriod": {
+                "type": "object",
+                "properties": {
                     "period_id": {
-                        "description": "The Id of the consumption period, used to reference the `previous_period_id` field.\n",
+                        "description": "The ID assigned to the specified billing period.",
                         "type": "string",
                         "format": "uuid"
                     },
-                    "data_storage_bytes_hour": {
-                        "description": "Bytes-Hour. The amount of storage the project consumed during the billing period. Expect some lag in the reported value.\nThe value is reset at the beginning of each billing period.\n",
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
-                    },
-                    "data_storage_bytes_hour_updated_at": {
-                        "description": "The timestamp of the last update of the `data_storage_bytes_hour` field.\n",
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "synthetic_storage_size": {
-                        "description": "Bytes. The current space occupied by project in storage. Expect some lag in the reported value.\n",
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
-                    },
-                    "synthetic_storage_size_updated_at": {
-                        "description": "The timestamp of the last update of the `synthetic_storage_size` field.\n",
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "data_transfer_bytes": {
-                        "description": "Bytes. The egress traffic from the Neon cloud to the client for the project over the billing period.\nIncludes egress traffic for deleted endpoints. Expect some lag in the reported value. The value is reset at the beginning of each billing period.\n",
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
-                    },
-                    "data_transfer_bytes_updated_at": {
-                        "description": "Timestamp of the last update of `data_transfer_bytes` field\n",
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "written_data_bytes": {
-                        "description": "Bytes. The Amount of WAL that travelled through storage for given project for all branches.\nExpect some lag in the reported value. The value is reset at the beginning of each billing period.\n",
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
-                    },
-                    "written_data_bytes_updated_at": {
-                        "description": "The timestamp of the last update of `written_data_bytes` field.\n",
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "compute_time_seconds": {
-                        "description": "Seconds. The number of CPU seconds used by the project's compute endpoints, including compute endpoints that have been deleted.\nExpect some lag in the reported value. The value is reset at the beginning of each billing period.\nExamples:\n1. An endpoint that uses 1 CPU for 1 second is equal to `compute_time=1`.\n2. An endpoint that uses 2 CPUs simultaneously for 1 second is equal to `compute_time=2`.\n",
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
-                    },
-                    "compute_time_seconds_updated_at": {
-                        "description": "The timestamp of the last update of `compute_time_seconds` field.\n",
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "active_time_seconds": {
-                        "description": "Seconds. The amount of time that compute endpoints in this project have been active.\nExpect some lag in the reported value.\n\nThe value is reset at the beginning of each billing period.\n",
-                        "type": "integer",
-                        "format": "int64",
-                        "minimum": 0
-                    },
-                    "active_time_seconds_updated_at": {
-                        "description": "The timestamp of the last update of the `active_time_seconds` field.\n",
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updated_at": {
-                        "description": "A timestamp indicating when the period was last updated.\n",
-                        "type": "string",
-                        "format": "date-time"
+                    "period_plan": {
+                        "description": "The billing plan applicable during the billing period.",
+                        "type": "string"
                     },
                     "period_start": {
-                        "description": "The start of the consumption period.\n",
+                        "description": "The start date-time of the billing period.\n",
                         "type": "string",
                         "format": "date-time"
                     },
                     "period_end": {
-                        "description": "The end of the consumption period.\n",
+                        "description": "The end date-time of the billing period, available for the past periods only.\n",
                         "type": "string",
-                        "format": "date-time",
-                        "nullable": true
+                        "format": "date-time"
                     },
-                    "previous_period_id": {
-                        "description": "The `period_id` of the previous consumption period.\n",
-                        "type": "string",
-                        "format": "uuid",
-                        "nullable": true
+                    "consumption": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ConsumptionHistoryPerTimeframe"
+                        }
                     }
+                },
+                "required": [
+                    "period_id",
+                    "period_plan",
+                    "period_start",
+                    "consumption"
+                ],
+                "example": {
+                    "period_id": "79ec829f-1828-4006-ac82-9f1828a0067d",
+                    "period_plan": "scale",
+                    "period_start": "2024-03-01T00:00:00Z",
+                    "consumption": [
+                        {
+                            "timeframe_start": "2024-03-22T00:00:00Z",
+                            "timeframe_end": "2024-03-23T00:00:00Z",
+                            "active_time_seconds": 27853,
+                            "compute_time_seconds": 18346,
+                            "written_data_bytes": 1073741824,
+                            "synthetic_storage_size_bytes": 5368709120
+                        },
+                        {
+                            "timeframe_start": "2024-03-23T00:00:00Z",
+                            "timeframe_end": "2024-03-24T00:00:00Z",
+                            "active_time_seconds": 17498,
+                            "compute_time_seconds": 3378,
+                            "written_data_bytes": 5741824,
+                            "synthetic_storage_size_bytes": 2370912
+                        }
+                    ]
                 }
+            },
+            "ConsumptionHistoryPerTimeframe": {
+                "type": "object",
+                "properties": {
+                    "timeframe_start": {
+                        "description": "The specified start date-time for the reported consumption.\n",
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "timeframe_end": {
+                        "description": "The specified end date-time for the reported consumption.\n",
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "active_time_seconds": {
+                        "description": "Seconds. The amount of time the compute endpoints have been active.\n",
+                        "type": "integer",
+                        "format": "uint64"
+                    },
+                    "compute_time_seconds": {
+                        "description": "Seconds. The number of CPU seconds used by compute endpoints, including compute endpoints that have been deleted.\n",
+                        "type": "integer",
+                        "format": "uint64"
+                    },
+                    "written_data_bytes": {
+                        "description": "Bytes. The amount of written data for all branches.\n",
+                        "type": "integer",
+                        "format": "uint64"
+                    },
+                    "synthetic_storage_size_bytes": {
+                        "description": "Bytes. The space occupied in storage. Synthetic storage size combines the logical data size and Write-Ahead Log (WAL) size for all branches.\n",
+                        "type": "integer",
+                        "format": "uint64"
+                    },
+                    "data_storage_bytes_hour": {
+                        "description": "Bytes-Hour. The amount of storage consumed hourly.\n",
+                        "type": "integer",
+                        "format": "uint64"
+                    }
+                },
+                "required": [
+                    "timeframe_start",
+                    "timeframe_end",
+                    "active_time_seconds",
+                    "compute_time_seconds",
+                    "written_data_bytes",
+                    "synthetic_storage_size_bytes"
+                ]
+            },
+            "ConsumptionHistoryGranularity": {
+                "type": "string",
+                "enum": [
+                    "hourly",
+                    "daily",
+                    "monthly"
+                ]
             },
             "ProjectLimits": {
                 "type": "object",
-                "additionalProperties": true,
                 "required": [
-                    "limits"
+                    "limits",
+                    "features"
                 ],
                 "properties": {
                     "limits": {
-                        "type": "object",
-                        "required": [
-                            "active_time",
-                            "max_projects",
-                            "max_branches",
-                            "max_autoscaling_cu",
-                            "cpu_seconds",
-                            "max_active_endpoints",
-                            "max_read_only_endpoints",
-                            "max_allowed_ips"
-                        ],
-                        "properties": {
-                            "active_time": {
-                                "type": "integer",
-                                "format": "int64"
-                            },
-                            "max_projects": {
-                                "type": "integer"
-                            },
-                            "max_branches": {
-                                "type": "integer"
-                            },
-                            "max_autoscaling_cu": {
-                                "type": "number",
-                                "format": "float64"
-                            },
-                            "cpu_seconds": {
-                                "type": "integer",
-                                "format": "int64"
-                            },
-                            "max_active_endpoints": {
-                                "type": "integer"
-                            },
-                            "max_read_only_endpoints": {
-                                "type": "integer"
-                            },
-                            "max_allowed_ips": {
-                                "type": "integer"
-                            }
-                        }
+                        "$ref": "#/components/schemas/Limits"
+                    },
+                    "features": {
+                        "$ref": "#/components/schemas/Features"
+                    }
+                }
+            },
+            "Limits": {
+                "type": "object",
+                "required": [
+                    "active_time",
+                    "max_projects",
+                    "max_branches",
+                    "max_protected_branches",
+                    "max_autoscaling_cu",
+                    "max_fixed_size_cu",
+                    "cpu_seconds",
+                    "max_compute_time_non_primary",
+                    "max_active_endpoints",
+                    "max_read_only_endpoints",
+                    "max_allowed_ips",
+                    "max_vpc_endpoints_per_region",
+                    "max_monitoring_retention_hours",
+                    "max_history_retention_seconds",
+                    "min_autosuspend_seconds",
+                    "max_data_transfer",
+                    "min_idle_seconds_to_autoarchive",
+                    "min_age_seconds_to_autoarchive",
+                    "max_branch_roles",
+                    "max_branch_databases",
+                    "max_concurrent_scheduled_operation_chains_per_project",
+                    "max_concurrent_executing_operation_chains_per_project"
+                ],
+                "properties": {
+                    "active_time": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "max_projects": {
+                        "type": "integer"
+                    },
+                    "max_branches": {
+                        "type": "integer"
+                    },
+                    "max_protected_branches": {
+                        "type": "integer"
+                    },
+                    "max_autoscaling_cu": {
+                        "type": "number",
+                        "format": "float64"
+                    },
+                    "max_fixed_size_cu": {
+                        "type": "number",
+                        "format": "float64"
+                    },
+                    "cpu_seconds": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "max_compute_time_non_primary": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "max_active_endpoints": {
+                        "type": "integer"
+                    },
+                    "max_read_only_endpoints": {
+                        "type": "integer"
+                    },
+                    "max_allowed_ips": {
+                        "type": "integer"
+                    },
+                    "max_vpc_endpoints_per_region": {
+                        "type": "integer"
+                    },
+                    "max_monitoring_retention_hours": {
+                        "type": "integer"
+                    },
+                    "max_history_retention_seconds": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "min_autosuspend_seconds": {
+                        "type": "integer"
+                    },
+                    "max_data_transfer": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "min_idle_seconds_to_autoarchive": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "min_age_seconds_to_autoarchive": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "max_branch_roles": {
+                        "type": "integer"
+                    },
+                    "max_branch_databases": {
+                        "type": "integer"
+                    },
+                    "max_concurrent_scheduled_operation_chains_per_project": {
+                        "type": "integer"
+                    },
+                    "max_concurrent_executing_operation_chains_per_project": {
+                        "type": "integer"
                     }
                 }
             },
@@ -4093,10 +6142,12 @@
                     "project_id",
                     "name",
                     "current_state",
+                    "state_changed_at",
                     "creation_source",
                     "created_at",
                     "updated_at",
-                    "primary",
+                    "default",
+                    "protected",
                     "cpu_used_sec",
                     "active_time_seconds",
                     "compute_time_seconds",
@@ -4106,15 +6157,18 @@
                 "properties": {
                     "id": {
                         "description": "The branch ID. This value is generated when a branch is created. A `branch_id` value has a `br` prefix. For example: `br-small-term-683261`.\n",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
                     "project_id": {
                         "description": "The ID of the project to which the branch belongs\n",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
                     "parent_id": {
                         "description": "The `branch_id` of the parent branch\n",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
                     "parent_lsn": {
                         "description": "The Log Sequence Number (LSN) on the parent branch from which this branch was created\n",
@@ -4135,6 +6189,11 @@
                     "pending_state": {
                         "$ref": "#/components/schemas/BranchState"
                     },
+                    "state_changed_at": {
+                        "description": "A UTC timestamp indicating when the `current_state` began\n",
+                        "type": "string",
+                        "format": "date-time"
+                    },
                     "logical_size": {
                         "description": "The logical size of the branch, in bytes\n",
                         "type": "integer",
@@ -4145,12 +6204,21 @@
                         "type": "string"
                     },
                     "primary": {
-                        "description": "Whether the branch is the project's primary branch\n",
+                        "deprecated": true,
+                        "description": "DEPRECATED. Use `default` field.\nWhether the branch is the project's primary branch\n",
+                        "type": "boolean"
+                    },
+                    "default": {
+                        "description": "Whether the branch is the project's default branch\n",
+                        "type": "boolean"
+                    },
+                    "protected": {
+                        "description": "Whether the branch is protected\n",
                         "type": "boolean"
                     },
                     "cpu_used_sec": {
                         "deprecated": true,
-                        "description": "CPU seconds used by all the endpoints of the branch, including deleted ones.\nThis value is reset at the beginning of each billing period.\nExamples:\n1. A branch that uses 1 CPU for 1 second is equal to `cpu_used_sec=1`.\n2. A branch that uses 2 CPUs simultaneously for 1 second is equal to `cpu_used_sec=2`.\n",
+                        "description": "CPU seconds used by all of the branch's compute endpoints, including deleted ones.\nThis value is reset at the beginning of each billing period.\nExamples:\n1. A branch that uses 1 CPU for 1 second is equal to `cpu_used_sec=1`.\n2. A branch that uses 2 CPUs simultaneously for 1 second is equal to `cpu_used_sec=2`.\n",
                         "type": "integer",
                         "format": "int64"
                     },
@@ -4184,6 +6252,20 @@
                         "description": "A timestamp indicating when the branch was last reset\n",
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "created_by": {
+                        "description": "The resolved user model that contains details of the user/org/integration/api_key used for branch creation. This field is filled only in listing/get/create/get/update/delete methods, if it is empty when calling other handlers, it does not mean that it is empty in the system.\n",
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "The name of the user."
+                            },
+                            "image": {
+                                "type": "string",
+                                "description": "The URL to the user's avatar image."
+                            }
+                        }
                     }
                 },
                 "example": {
@@ -4192,20 +6274,18 @@
                     "parent_id": "br-aged-salad-637688",
                     "parent_lsn": "0/1DE2850",
                     "name": "dev2",
+                    "protected": false,
                     "current_state": "ready",
+                    "state_changed_at": "2022-11-30T20:09:48Z",
                     "creation_source": "console",
                     "created_at": "2022-11-30T19:09:48Z",
                     "updated_at": "2022-12-01T19:53:05Z",
-                    "primary": true
+                    "default": true
                 }
             },
             "BranchState": {
-                "description": "The branch state",
-                "type": "string",
-                "enum": [
-                    "init",
-                    "ready"
-                ]
+                "description": "The branch\u2019s state, indicating if it is initializing, ready for use, or archived.\n  * 'init' - the branch is being created but is not available for querying.\n  * 'ready' - the branch is fully operational and ready for querying. Expect normal query response times.\n  * 'archived' - the branch is stored in cost-effective archival storage. Expect slow query response times.\n",
+                "type": "string"
             },
             "BranchCreateRequestEndpointOptions": {
                 "type": "object",
@@ -4245,8 +6325,9 @@
                         "type": "object",
                         "properties": {
                             "parent_id": {
-                                "description": "The `branch_id` of the parent branch. If omitted or empty, the branch will be created from the project's primary branch.\n",
-                                "type": "string"
+                                "description": "The `branch_id` of the parent branch. If omitted or empty, the branch will be created from the project's default branch.\n",
+                                "type": "string",
+                                "pattern": "^[a-z0-9-]{1,60}$"
                             },
                             "name": {
                                 "description": "The branch name\n",
@@ -4257,9 +6338,21 @@
                                 "type": "string"
                             },
                             "parent_timestamp": {
-                                "description": "A timestamp identifying a point in time on the parent branch. The branch will be created with data starting from this point in time.\n",
+                                "description": "A timestamp identifying a point in time on the parent branch. The branch will be created with data starting from this point in time.\nThe timestamp must be provided in ISO 8601 format; for example: `2024-02-26T12:00:00Z`.\n",
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "protected": {
+                                "description": "Whether the branch is protected\n",
+                                "type": "boolean"
+                            },
+                            "archived": {
+                                "description": "Whether to create the branch as archived\n",
+                                "type": "boolean"
+                            },
+                            "init_source": {
+                                "description": "The initialization source type for the branch. Valid values are `import`, `empty`, `schema` and `parent-data`.\nThis parameter is under active development and may change its semantics in the future.\n",
+                                "type": "string"
                             }
                         }
                     }
@@ -4276,8 +6369,37 @@
                         "properties": {
                             "name": {
                                 "type": "string"
+                            },
+                            "protected": {
+                                "type": "boolean"
                             }
                         }
+                    }
+                }
+            },
+            "BranchRestoreRequest": {
+                "type": "object",
+                "required": [
+                    "source_branch_id"
+                ],
+                "properties": {
+                    "source_branch_id": {
+                        "description": "The `branch_id` of the restore source branch.\nIf `source_timestamp` and `source_lsn` are omitted, the branch will be restored to head.\nIf `source_branch_id` is equal to the branch's id, `source_timestamp` or `source_lsn` is required.\n",
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    },
+                    "source_lsn": {
+                        "description": "A Log Sequence Number (LSN) on the source branch. The branch will be restored with data from this LSN.\n",
+                        "type": "string"
+                    },
+                    "source_timestamp": {
+                        "description": "A timestamp identifying a point in time on the source branch. The branch will be restored with data starting from this point in time.\nThe timestamp must be provided in ISO 8601 format; for example: `2024-02-26T12:00:00Z`.\n",
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "preserve_under_name": {
+                        "description": "If not empty, the previous state of the branch will be saved to a branch with this name.\nIf the branch has children or the `source_branch_id` is equal to the branch id, this field is required. All existing child branches will be moved to the newly created branch under the name `preserve_under_name`.\n",
+                        "type": "string"
                     }
                 }
             },
@@ -4289,6 +6411,22 @@
                 "properties": {
                     "branch": {
                         "$ref": "#/components/schemas/Branch"
+                    }
+                }
+            },
+            "BranchSchemaResponse": {
+                "type": "object",
+                "properties": {
+                    "sql": {
+                        "type": "string"
+                    }
+                }
+            },
+            "BranchSchemaCompareResponse": {
+                "type": "object",
+                "properties": {
+                    "diff": {
+                        "type": "string"
                     }
                 }
             },
@@ -4306,6 +6444,18 @@
                     }
                 }
             },
+            "BranchesCountResponse": {
+                "type": "object",
+                "required": [
+                    "count"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "format": "int"
+                    }
+                }
+            },
             "ConnectionParameters": {
                 "type": "object",
                 "required": [
@@ -4317,23 +6467,23 @@
                 ],
                 "properties": {
                     "database": {
-                        "description": "Database name.\n",
+                        "description": "Database name\n",
                         "type": "string"
                     },
                     "password": {
-                        "description": "Password for the role.\n",
+                        "description": "Password for the role\n",
                         "type": "string"
                     },
                     "role": {
-                        "description": "Role name.\n",
+                        "description": "Role name\n",
                         "type": "string"
                     },
                     "host": {
-                        "description": "Host name.\n",
+                        "description": "Hostname\n",
                         "type": "string"
                     },
                     "pooler_host": {
-                        "description": "Pooler host name.\n",
+                        "description": "Pooler hostname\n",
                         "type": "string"
                     }
                 }
@@ -4346,11 +6496,23 @@
                 ],
                 "properties": {
                     "connection_uri": {
-                        "description": "Connection URI is same as specified in https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6\nIt is a ready to use string for psql or for DATABASE_URL environment variable.\n",
+                        "description": "The connection URI is defined as specified here: [Connection URIs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS)\nThe connection URI can be used to connect to a Postgres database with psql or defined in a DATABASE_URL environment variable.\nWhen creating a branch from a parent with more than one role or database, the response body does not include a connection URI.\n",
                         "type": "string"
                     },
                     "connection_parameters": {
                         "$ref": "#/components/schemas/ConnectionParameters"
+                    }
+                }
+            },
+            "ConnectionURIResponse": {
+                "type": "object",
+                "required": [
+                    "uri"
+                ],
+                "properties": {
+                    "uri": {
+                        "description": "The connection URI.\n",
+                        "type": "string"
                     }
                 }
             },
@@ -4385,15 +6547,18 @@
                     },
                     "id": {
                         "description": "The compute endpoint ID. Compute endpoint IDs have an `ep-` prefix. For example: `ep-little-smoke-851426`\n",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
                     "project_id": {
                         "description": "The ID of the project to which the compute endpoint belongs\n",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
                     "branch_id": {
                         "description": "The ID of the branch that the compute endpoint is associated with\n",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
                     "autoscaling_limit_min_cu": {
                         "description": "The minimum number of Compute Units\n",
@@ -4462,6 +6627,10 @@
                     },
                     "provisioner": {
                         "$ref": "#/components/schemas/Provisioner"
+                    },
+                    "compute_release_version": {
+                        "description": "Attached compute's release version number.\n",
+                        "type": "string"
                     }
                 },
                 "example": {
@@ -4499,7 +6668,7 @@
                 ]
             },
             "EndpointType": {
-                "description": "The compute endpoint type. Either `read_write` or `read_only`.\nThe `read_only` compute endpoint type is not yet supported.\n",
+                "description": "The compute endpoint type. Either `read_write` or `read_only`.\n",
                 "type": "string",
                 "enum": [
                     "read_only",
@@ -4514,18 +6683,15 @@
                 ]
             },
             "SuspendTimeoutSeconds": {
-                "description": "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the global default.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Auto-suspend configuration](https://neon.tech/docs/manage/endpoints#auto-suspend-configuration).\n",
+                "description": "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.tech/docs/manage/endpoints#scale-to-zero-configuration).\n",
                 "type": "integer",
                 "format": "int64",
                 "minimum": -1,
                 "maximum": 604800
             },
             "AllowedIps": {
-                "description": "A list of IP addresses that are allowed to connect to the endpoint.\nIf the list is empty or not set, all IP addresses are allowed.\nIf primary_branch_only is true, the list will be applied only to the primary branch.\n",
+                "description": "A list of IP addresses that are allowed to connect to the compute endpoint.\nIf the list is empty or not set, all IP addresses are allowed.\nIf protected_branches_only is true, the list will be applied only to protected branches.\n",
                 "type": "object",
-                "required": [
-                    "primary_branch_only"
-                ],
                 "properties": {
                     "ips": {
                         "description": "A list of IP addresses that are allowed to connect to the endpoint.",
@@ -4534,9 +6700,35 @@
                             "type": "string"
                         }
                     },
-                    "primary_branch_only": {
-                        "description": "If true, the list will be applied only to the primary branch.",
+                    "protected_branches_only": {
+                        "description": "If true, the list will be applied only to protected branches.",
                         "type": "boolean"
+                    }
+                }
+            },
+            "MaintenanceWindow": {
+                "description": "A maintenance window is a time period during which Neon may perform maintenance on the project's infrastructure.\nDuring this time, the project's compute endpoints may be unavailable and existing connections can be\ninterrupted.\n",
+                "type": "object",
+                "required": [
+                    "weekdays",
+                    "start_time",
+                    "end_time"
+                ],
+                "properties": {
+                    "weekdays": {
+                        "description": "A list of weekdays when the maintenance window is active.\nEncoded as ints, where 1 - Monday, and 7 - Sunday.\n",
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "start_time": {
+                        "description": "Start time of the maintenance window, in the format of \"HH:MM\". Uses UTC.\n",
+                        "type": "string"
+                    },
+                    "end_time": {
+                        "description": "End time of the maintenance window, in the format of \"HH:MM\". Uses UTC.\n",
+                        "type": "string"
                     }
                 }
             },
@@ -4555,7 +6747,8 @@
                         "properties": {
                             "branch_id": {
                                 "description": "The ID of the branch the compute endpoint will be associated with\n",
-                                "type": "string"
+                                "type": "string",
+                                "pattern": "^[a-z0-9-]{1,60}$"
                             },
                             "region_id": {
                                 "description": "The region where the compute endpoint will be created. Only the project's `region_id` is permitted.\n",
@@ -4611,8 +6804,10 @@
                         "type": "object",
                         "properties": {
                             "branch_id": {
-                                "description": "The destination branch ID. The destination branch must not have an exsiting read-write endpoint.\n",
-                                "type": "string"
+                                "deprecated": true,
+                                "description": "DEPRECATED: This field will be removed in a future release.\nThe destination branch ID. The destination branch must not have an exsiting read-write endpoint.\n",
+                                "type": "string",
+                                "pattern": "^[a-z0-9-]{1,60}$"
                             },
                             "autoscaling_limit_min_cu": {
                                 "description": "The minimum number of Compute Units. The minimum value is `0.25`.\nSee [Compute size and Autoscaling configuration](https://neon.tech/docs/manage/endpoints#compute-size-and-autoscaling-configuration)\nfor more information.\n",
@@ -4684,6 +6879,81 @@
                         "items": {
                             "$ref": "#/components/schemas/ConnectionDetails"
                         }
+                    }
+                }
+            },
+            "VPCEndpointsResponse": {
+                "type": "object",
+                "required": [
+                    "endpoints"
+                ],
+                "properties": {
+                    "endpoints": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/VPCEndpoint"
+                        }
+                    }
+                }
+            },
+            "VPCEndpoint": {
+                "type": "object",
+                "required": [
+                    "vpc_endpoint_id",
+                    "label"
+                ],
+                "properties": {
+                    "vpc_endpoint_id": {
+                        "type": "string"
+                    },
+                    "label": {
+                        "type": "string"
+                    }
+                }
+            },
+            "VPCEndpointDetails": {
+                "type": "object",
+                "required": [
+                    "vpc_endpoint_id",
+                    "label",
+                    "state",
+                    "num_restricted_projects",
+                    "example_restricted_projects"
+                ],
+                "properties": {
+                    "vpc_endpoint_id": {
+                        "description": "The ID of the VPC endpoint",
+                        "type": "string"
+                    },
+                    "label": {
+                        "description": "The custom descriptive label for the VPC endpoint",
+                        "type": "string"
+                    },
+                    "state": {
+                        "description": "The current state of the VPC endpoint. Possible values are\n`new` (just configured, pending acceptance) or `accepted`\n(VPC connection was accepted by Neon).\n",
+                        "type": "string"
+                    },
+                    "num_restricted_projects": {
+                        "description": "The number of projects that are restricted to use this VPC endpoint.\n",
+                        "type": "integer"
+                    },
+                    "example_restricted_projects": {
+                        "description": "A list of example projects that are restricted to use this VPC endpoint.\nThere are at most 3 projects in the list, even if more projects are restricted.\n",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "VPCEndpointAssignment": {
+                "type": "object",
+                "required": [
+                    "label"
+                ],
+                "properties": {
+                    "label": {
+                        "type": "string"
                     }
                 }
             },
@@ -4788,7 +7058,8 @@
                 "properties": {
                     "branch_id": {
                         "description": "The ID of the branch to which the role belongs\n",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
                     "name": {
                         "description": "The role name\n",
@@ -4849,6 +7120,17 @@
                 "properties": {
                     "role": {
                         "$ref": "#/components/schemas/Role"
+                    }
+                }
+            },
+            "JWKSResponse": {
+                "type": "object",
+                "required": [
+                    "jwks"
+                ],
+                "properties": {
+                    "jwks": {
+                        "$ref": "#/components/schemas/JWKS"
                     }
                 }
             },
@@ -4932,9 +7214,12 @@
             "BillingAccount": {
                 "type": "object",
                 "required": [
+                    "state",
                     "payment_source",
                     "subscription_type",
+                    "payment_method",
                     "quota_reset_at_last",
+                    "name",
                     "email",
                     "address_city",
                     "address_country",
@@ -4944,16 +7229,26 @@
                     "address_state"
                 ],
                 "properties": {
+                    "state": {
+                        "$ref": "#/components/schemas/BillingAccountState"
+                    },
                     "payment_source": {
                         "$ref": "#/components/schemas/PaymentSource"
                     },
                     "subscription_type": {
                         "$ref": "#/components/schemas/BillingSubscriptionType"
                     },
+                    "payment_method": {
+                        "$ref": "#/components/schemas/BillingPaymentMethod"
+                    },
                     "quota_reset_at_last": {
                         "description": "The last time the quota was reset. Defaults to the date-time the account is created.\n",
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "name": {
+                        "description": "The full name of the individual or entity that owns the billing account. This name appears on invoices.",
+                        "type": "string"
                     },
                     "email": {
                         "description": "Billing email, to receive emails related to invoices and subscriptions.\n",
@@ -4964,7 +7259,11 @@
                         "type": "string"
                     },
                     "address_country": {
-                        "description": "Billing address country.\n",
+                        "description": "Billing address country code defined by ISO 3166-1 alpha-2.\n",
+                        "type": "string"
+                    },
+                    "address_country_name": {
+                        "description": "Billing address country name.\n",
                         "type": "string"
                     },
                     "address_line1": {
@@ -4986,49 +7285,56 @@
                     "orb_portal_url": {
                         "description": "Orb user portal url\n",
                         "type": "string"
+                    },
+                    "tax_id": {
+                        "description": "The tax identification number for the billing account, displayed on invoices.\n",
+                        "type": "string"
+                    },
+                    "tax_id_type": {
+                        "description": "The type of the tax identification number based on the country.\n",
+                        "type": "string"
                     }
                 }
             },
-            "BillingAccountUpdateRequest": {
-                "type": "object",
-                "required": [
-                    "billing_account"
-                ],
-                "properties": {
-                    "billing_account": {
-                        "type": "object",
-                        "properties": {
-                            "email": {
-                                "description": "Billing email, to receive emails related to invoices and subscriptions.\n",
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "BillingAccountResponse": {
-                "type": "object",
-                "required": [
-                    "billing_account"
-                ],
-                "properties": {
-                    "billing_account": {
-                        "$ref": "#/components/schemas/BillingAccount"
-                    }
-                }
+            "BillingAccountState": {
+                "type": "string",
+                "description": "State of the billing account.\n",
+                "enum": [
+                    "UNKNOWN",
+                    "active",
+                    "suspended",
+                    "deactivated",
+                    "deleted"
+                ]
             },
             "BillingSubscriptionType": {
                 "type": "string",
                 "description": "Type of subscription to Neon Cloud.\nNotice that for users without billing account this will be \"UNKNOWN\"\n",
                 "enum": [
                     "UNKNOWN",
-                    "free",
-                    "pro",
                     "direct_sales",
                     "aws_marketplace",
                     "free_v2",
                     "launch",
-                    "scale"
+                    "scale",
+                    "business",
+                    "vercel_pg_legacy"
+                ]
+            },
+            "BillingPaymentMethod": {
+                "type": "string",
+                "description": "Indicates whether and how an account makes payments.\n",
+                "enum": [
+                    "UNKNOWN",
+                    "none",
+                    "stripe",
+                    "direct_payment",
+                    "aws_mp",
+                    "azure_mp",
+                    "vercel_mp",
+                    "staff",
+                    "trial",
+                    "sponsorship"
                 ]
             },
             "Database": {
@@ -5049,7 +7355,8 @@
                     },
                     "branch_id": {
                         "description": "The ID of the branch to which the database belongs\n",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
                     },
                     "name": {
                         "description": "The database name\n",
@@ -5150,6 +7457,402 @@
                     }
                 }
             },
+            "Invitation": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "email",
+                    "org_id",
+                    "invited_by",
+                    "invited_at",
+                    "role"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "email": {
+                        "description": "Email of the invited user",
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "org_id": {
+                        "description": "Organization id as it is stored in Neon",
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    },
+                    "invited_by": {
+                        "description": "UUID for the user_id who extended the invitation",
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "invited_at": {
+                        "description": "Timestamp when the invitation was created",
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/MemberRole"
+                    }
+                }
+            },
+            "MemberRole": {
+                "description": "The role of the organization member",
+                "type": "string",
+                "enum": [
+                    "admin",
+                    "member"
+                ]
+            },
+            "Member": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "user_id",
+                    "org_id",
+                    "role"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "user_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "org_id": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/MemberRole"
+                    },
+                    "joined_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            },
+            "MemberUserInfo": {
+                "type": "object",
+                "required": [
+                    "email"
+                ],
+                "properties": {
+                    "email": {
+                        "type": "string"
+                    }
+                }
+            },
+            "MemberWithUser": {
+                "type": "object",
+                "required": [
+                    "member",
+                    "user"
+                ],
+                "properties": {
+                    "member": {
+                        "$ref": "#/components/schemas/Member"
+                    },
+                    "user": {
+                        "$ref": "#/components/schemas/MemberUserInfo"
+                    }
+                }
+            },
+            "Organization": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "name",
+                    "handle",
+                    "plan",
+                    "created_at",
+                    "updated_at",
+                    "managed_by"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "handle": {
+                        "type": "string"
+                    },
+                    "plan": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "description": "A timestamp indicting when the organization was created\n",
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "managed_by": {
+                        "description": "Organizations created via the Console or the API are managed by `console`.\nOrganizations created by other methods can't be deleted via the Console or the API.\n",
+                        "type": "string"
+                    },
+                    "updated_at": {
+                        "description": "A timestamp indicating when the organization was updated\n",
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            },
+            "OrganizationsResponse": {
+                "type": "object",
+                "required": [
+                    "organizations"
+                ],
+                "properties": {
+                    "organizations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Organization"
+                        }
+                    }
+                }
+            },
+            "OrganizationsUpdateRequest": {
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 64
+                    }
+                }
+            },
+            "OrganizationInvitationsResponse": {
+                "type": "object",
+                "required": [
+                    "invitations"
+                ],
+                "properties": {
+                    "invitations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Invitation"
+                        }
+                    }
+                }
+            },
+            "OrganizationInviteCreateRequest": {
+                "type": "object",
+                "required": [
+                    "email",
+                    "role"
+                ],
+                "properties": {
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                        "minLength": 1,
+                        "maxLength": 500
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/MemberRole"
+                    }
+                }
+            },
+            "OrganizationInvitesCreateRequest": {
+                "type": "object",
+                "required": [
+                    "invitations"
+                ],
+                "properties": {
+                    "invitations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/OrganizationInviteCreateRequest"
+                        }
+                    }
+                }
+            },
+            "OrganizationInviteUpdateRequest": {
+                "type": "object",
+                "properties": {
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/MemberRole"
+                    },
+                    "resend": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "OrganizationGuestsResponse": {
+                "description": "A list of details for guests of an organization\n",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/OrganizationGuest"
+                }
+            },
+            "OrganizationGuest": {
+                "description": "Details of an organization guest, who is not directly a member of\nan organization but has been shared one of the projects it owns\n",
+                "type": "object",
+                "required": [
+                    "permission_id",
+                    "user_email",
+                    "project_id",
+                    "project_name"
+                ],
+                "properties": {
+                    "permission_id": {
+                        "type": "string"
+                    },
+                    "user_email": {
+                        "type": "string"
+                    },
+                    "project_id": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    },
+                    "project_name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "OrganizationMemberUpdateRequest": {
+                "type": "object",
+                "required": [
+                    "role"
+                ],
+                "properties": {
+                    "role": {
+                        "$ref": "#/components/schemas/MemberRole"
+                    }
+                }
+            },
+            "OrganizationMembersResponse": {
+                "type": "object",
+                "required": [
+                    "members"
+                ],
+                "properties": {
+                    "members": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MemberWithUser"
+                        }
+                    }
+                }
+            },
+            "InvitationCreateRequest": {
+                "type": "object",
+                "required": [
+                    "email",
+                    "role"
+                ],
+                "properties": {
+                    "email": {
+                        "description": "Email to invite",
+                        "type": "string"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/MemberRole"
+                    }
+                }
+            },
+            "OrganizationCreateRequest": {
+                "type": "object",
+                "required": [
+                    "organization",
+                    "subscription_type"
+                ],
+                "properties": {
+                    "organization": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "description": "The organization name",
+                                "type": "string",
+                                "maxLength": 64
+                            },
+                            "invitations": {
+                                "description": "Emails with roles to invite to the organization",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/InvitationCreateRequest"
+                                }
+                            }
+                        }
+                    },
+                    "subscription_type": {
+                        "$ref": "#/components/schemas/BillingSubscriptionType"
+                    }
+                }
+            },
+            "OrganizationLimits": {
+                "type": "object",
+                "required": [
+                    "limits",
+                    "features"
+                ],
+                "properties": {
+                    "limits": {
+                        "$ref": "#/components/schemas/Limits"
+                    },
+                    "features": {
+                        "$ref": "#/components/schemas/Features"
+                    }
+                }
+            },
+            "ActiveRegionsResponse": {
+                "type": "object",
+                "required": [
+                    "regions"
+                ],
+                "properties": {
+                    "regions": {
+                        "type": "array",
+                        "description": "The list of active regions",
+                        "items": {
+                            "$ref": "#/components/schemas/RegionResponse"
+                        }
+                    }
+                }
+            },
+            "RegionResponse": {
+                "type": "object",
+                "required": [
+                    "region_id",
+                    "name",
+                    "default",
+                    "geo_lat",
+                    "geo_long"
+                ],
+                "properties": {
+                    "region_id": {
+                        "type": "string",
+                        "description": "The region ID as used in other API endpoints"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "A short description of the region."
+                    },
+                    "default": {
+                        "type": "boolean",
+                        "description": "Whether this region is used by default in new projects."
+                    },
+                    "geo_lat": {
+                        "type": "string",
+                        "description": "The geographical latitude (approximate) for the region. Empty if unknown."
+                    },
+                    "geo_long": {
+                        "type": "string",
+                        "description": "The geographical longitude (approximate) for the region. Empty if unknown."
+                    }
+                }
+            },
             "CurrentUserAuthAccount": {
                 "type": "object",
                 "required": [
@@ -5167,12 +7870,33 @@
                         "type": "string"
                     },
                     "login": {
-                        "type": "string"
+                        "type": "string",
+                        "deprecated": true,
+                        "description": "DEPRECATED. Use `email` field.\n"
                     },
                     "name": {
                         "type": "string"
                     },
                     "provider": {
+                        "$ref": "#/components/schemas/IdentityProviderId"
+                    }
+                }
+            },
+            "LinkedAuthAccount": {
+                "type": "object",
+                "required": [
+                    "provider",
+                    "provider_display_name",
+                    "username"
+                ],
+                "properties": {
+                    "provider": {
+                        "$ref": "#/components/schemas/IdentityProviderId"
+                    },
+                    "provider_display_name": {
+                        "type": "string"
+                    },
+                    "username": {
                         "type": "string"
                     }
                 }
@@ -5180,8 +7904,7 @@
             "UpdateUserInfoRequest": {
                 "type": "object",
                 "required": [
-                    "id",
-                    "email"
+                    "id"
                 ],
                 "properties": {
                     "email": {
@@ -5192,12 +7915,20 @@
                         "format": "uuid"
                     },
                     "image": {
-                        "type": "string"
+                        "type": "string",
+                        "deprecated": true,
+                        "description": "DEPRECATED. This field is ignored.\n"
                     },
                     "first_name": {
                         "type": "string"
                     },
                     "last_name": {
+                        "type": "string"
+                    },
+                    "password": {
+                        "type": "string"
+                    },
+                    "new_password": {
                         "type": "string"
                     }
                 }
@@ -5244,7 +7975,9 @@
                         "type": "string"
                     },
                     "login": {
-                        "type": "string"
+                        "type": "string",
+                        "deprecated": true,
+                        "description": "DEPRECATED. Use `email` field.\n"
                     },
                     "name": {
                         "type": "string"
@@ -5271,6 +8004,95 @@
                         "type": "string"
                     }
                 }
+            },
+            "ConvertUserToOrgRequest": {
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 64
+                    }
+                }
+            },
+            "CurrentUserInfoAuthResponse": {
+                "type": "object",
+                "required": [
+                    "password_stored",
+                    "auth_accounts",
+                    "linked_accounts",
+                    "provider"
+                ],
+                "properties": {
+                    "password_stored": {
+                        "type": "boolean"
+                    },
+                    "auth_accounts": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/CurrentUserAuthAccount"
+                        }
+                    },
+                    "linked_accounts": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/LinkedAuthAccount"
+                        }
+                    },
+                    "provider": {
+                        "type": "string"
+                    }
+                }
+            },
+            "TransferProjectsToOrganizationRequest": {
+                "type": "object",
+                "required": [
+                    "org_id",
+                    "project_ids"
+                ],
+                "properties": {
+                    "org_id": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    },
+                    "project_ids": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 400,
+                        "items": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]{1,60}$"
+                        },
+                        "description": "The list of projects ids to transfer. Maximum of 400 project ids"
+                    }
+                }
+            },
+            "VerifyUserPasswordRequest": {
+                "type": "object",
+                "required": [
+                    "password"
+                ],
+                "properties": {
+                    "password": {
+                        "type": "string"
+                    }
+                }
+            },
+            "IdentityProviderId": {
+                "description": "Identity provider id from keycloak",
+                "type": "string",
+                "enum": [
+                    "github",
+                    "google",
+                    "hasura",
+                    "microsoft",
+                    "microsoftv2",
+                    "vercelmp",
+                    "keycloak",
+                    "test"
+                ]
             },
             "EndpointSettingsData": {
                 "type": "object",
@@ -5347,7 +8169,7 @@
                 }
             },
             "PgSettingsData": {
-                "description": "A raw representation of PostgreSQL settings",
+                "description": "A raw representation of Postgres settings",
                 "type": "object",
                 "additionalProperties": {
                     "type": "string"
@@ -5361,11 +8183,11 @@
                 }
             },
             "PgVersion": {
-                "description": "The major PostgreSQL version number. Currently supported versions are `14`, `15` and `16`.",
+                "description": "The major Postgres version number. Currently supported versions are `14`, `15`, `16`, and `17`.",
                 "type": "integer",
                 "minimum": 14,
-                "maximum": 16,
-                "default": 15
+                "maximum": 17,
+                "default": 17
             },
             "HealthCheck": {
                 "type": "object",
@@ -5386,6 +8208,7 @@
                 "type": "object",
                 "required": [
                     "email",
+                    "name",
                     "branches_limit",
                     "subscription_type"
                 ],
@@ -5393,11 +8216,165 @@
                     "email": {
                         "type": "string"
                     },
+                    "name": {
+                        "type": "string"
+                    },
                     "branches_limit": {
                         "type": "integer"
                     },
                     "subscription_type": {
                         "$ref": "#/components/schemas/BillingSubscriptionType"
+                    }
+                }
+            },
+            "LimitsUnsatisfiedResponse": {
+                "type": "object",
+                "required": [
+                    "limits"
+                ],
+                "properties": {
+                    "limits": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name",
+                                "expected",
+                                "actual"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "expected": {
+                                    "type": "string"
+                                },
+                                "actual": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "example": {
+                    "limits": [
+                        {
+                            "name": "projects_count",
+                            "actual": "2",
+                            "expected": "1"
+                        },
+                        {
+                            "name": "subscription_type",
+                            "actual": "launch",
+                            "expected": "scale"
+                        }
+                    ]
+                }
+            },
+            "ProjectsWithIntegrationResponse": {
+                "type": "object",
+                "required": [
+                    "projects"
+                ],
+                "properties": {
+                    "projects": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "id",
+                                "integration"
+                            ],
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "pattern": "^[a-z0-9-]{1,60}$"
+                                },
+                                "integration": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "example": {
+                    "projects": [
+                        {
+                            "id": "round-frog-53611540",
+                            "integration": "github"
+                        },
+                        {
+                            "id": "long-leaf-72329067",
+                            "integration": "vercel"
+                        },
+                        {
+                            "id": "shrill-bush-06966719",
+                            "integration": "outerbase"
+                        }
+                    ]
+                }
+            },
+            "UserDeletionConditionName": {
+                "type": "string",
+                "enum": [
+                    "project_count",
+                    "org_admin_membership_count",
+                    "subscription_type"
+                ]
+            },
+            "OrgDeletionConditionName": {
+                "type": "string",
+                "enum": [
+                    "project_count"
+                ]
+            },
+            "IdentitySupportedAuthProvider": {
+                "type": "string",
+                "enum": [
+                    "mock",
+                    "stack"
+                ]
+            },
+            "ListProjectIdentityIntegrationsResponse": {
+                "type": "object",
+                "required": [
+                    "data"
+                ],
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/IdentityIntegration"
+                        }
+                    }
+                }
+            },
+            "IdentityIntegration": {
+                "type": "object",
+                "required": [
+                    "auth_provider",
+                    "auth_provider_project_id",
+                    "branch_id",
+                    "db_name",
+                    "created_at"
+                ],
+                "properties": {
+                    "auth_provider": {
+                        "type": "string"
+                    },
+                    "auth_provider_project_id": {
+                        "type": "string"
+                    },
+                    "branch_id": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9-]{1,60}$"
+                    },
+                    "db_name": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
                     }
                 }
             },
@@ -5409,6 +8386,9 @@
                     "code"
                 ],
                 "properties": {
+                    "request_id": {
+                        "type": "string"
+                    },
                     "code": {
                         "$ref": "#/components/schemas/ErrorCode"
                     },
@@ -5461,6 +8441,16 @@
                     }
                 ]
             },
+            "JWKSCreationOperation": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JWKSResponse"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OperationsResponse"
+                    }
+                ]
+            },
             "SupportTicketSeverity": {
                 "type": "string",
                 "enum": [
@@ -5469,6 +8459,231 @@
                     "high",
                     "critical"
                 ]
+            },
+            "AnnotationData": {
+                "type": "object",
+                "x-tags": [
+                    "Branch"
+                ],
+                "required": [
+                    "object",
+                    "value"
+                ],
+                "properties": {
+                    "object": {
+                        "$ref": "#/components/schemas/AnnotationObjectData"
+                    },
+                    "value": {
+                        "$ref": "#/components/schemas/AnnotationValueData"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            },
+            "AnnotationValueData": {
+                "type": "object",
+                "description": "Annotation properties.",
+                "x-tags": [
+                    "Branch"
+                ],
+                "maxProperties": 50,
+                "additionalProperties": {
+                    "type": "string",
+                    "example": {
+                        "github-commit-ref": "github-branch-name"
+                    }
+                }
+            },
+            "AnnotationObjectData": {
+                "type": "object",
+                "x-tags": [
+                    "Branch"
+                ],
+                "required": [
+                    "type",
+                    "id"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "AnnotationCreateValueRequest": {
+                "type": "object",
+                "x-tags": [
+                    "Branch"
+                ],
+                "properties": {
+                    "annotation_value": {
+                        "$ref": "#/components/schemas/AnnotationValueData"
+                    }
+                }
+            },
+            "AnnotationResponse": {
+                "type": "object",
+                "x-tags": [
+                    "Branch"
+                ],
+                "required": [
+                    "annotation"
+                ],
+                "properties": {
+                    "annotation": {
+                        "$ref": "#/components/schemas/AnnotationData"
+                    }
+                }
+            },
+            "AnnotationsMapResponse": {
+                "type": "object",
+                "x-tags": [
+                    "Branch"
+                ],
+                "required": [
+                    "annotations"
+                ],
+                "properties": {
+                    "annotations": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/AnnotationData"
+                        }
+                    }
+                }
+            },
+            "ProjectsApplicationsMapResponse": {
+                "type": "object",
+                "x-tags": [
+                    "Project"
+                ],
+                "description": "A map where key is a project ID and a value is a list of installed applications.\n",
+                "required": [
+                    "applications"
+                ],
+                "properties": {
+                    "applications": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "vercel",
+                                    "github",
+                                    "datadog"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "example": {
+                    "winter-boat-259881": [
+                        "vercel",
+                        "github",
+                        "datadog"
+                    ]
+                }
+            },
+            "ProjectsIntegrationsMapResponse": {
+                "type": "object",
+                "x-tags": [
+                    "Project"
+                ],
+                "description": "A map where key is a project ID and a value is a list of installed integrations.\n",
+                "required": [
+                    "integrations"
+                ],
+                "properties": {
+                    "integrations": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "vercel",
+                                    "github",
+                                    "datadog"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "example": {
+                    "winter-boat-259881": [
+                        "vercel",
+                        "github",
+                        "datadog"
+                    ]
+                }
+            },
+            "CursorPaginationResponse": {
+                "type": "object",
+                "properties": {
+                    "pagination": {
+                        "$ref": "#/components/schemas/CursorPagination"
+                    }
+                }
+            },
+            "CursorPagination": {
+                "type": "object",
+                "description": "To paginate the response, issue an initial request with `limit` value. Then, add the value returned in the response `.pagination.next` attribute into the request under the `cursor` query parameter to the subsequent request to retrieve next page in pagination. Using `.pagination.previous` as cursor will return the previous page. The contents on cursor `next` and `previous` are opaque, clients are not expected to make any assumptions on the format of the data inside the cursor.",
+                "properties": {
+                    "next": {
+                        "type": "string"
+                    },
+                    "previous": {
+                        "type": "string"
+                    },
+                    "sort_by": {
+                        "type": "string"
+                    },
+                    "sort_order": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "parameters": {
+            "CursorParam": {
+                "name": "cursor",
+                "description": "A cursor to use in pagination. A cursor defines your place in the data list. Include `response.pagination.next` or `response.pagination.previous` in subsequent API calls to fetch next or previous page of the list.",
+                "in": "query",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "LimitParam": {
+                "name": "limit",
+                "description": "The maximum number of records to be returned in the response",
+                "in": "query",
+                "schema": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10000
+                }
+            },
+            "SortOrderParam": {
+                "name": "sort_order",
+                "description": "Defines the sorting order of entities.",
+                "in": "query",
+                "schema": {
+                    "type": "string",
+                    "default": "desc",
+                    "enum": [
+                        "asc",
+                        "desc"
+                    ]
+                }
             }
         }
     }


### PR DESCRIPTION
```
(venv) ~/s/neon-api-python ❯❯❯ make test                                                            bump-schema
set -a && source .env && set +a; pytest --record-mode=none tests/
============================================= test session starts ==============================================
platform darwin -- Python 3.12.6, pytest-8.3.3, pluggy-1.5.0
rootdir: /Users/david/src/neon-api-python
configfile: pyproject.toml
plugins: recording-0.13.2, cov-6.0.0, ordering-0.6
collected 8 items

tests/test_integration.py ........                                                                       [100%]

============================================== 8 passed in 0.40s ===============================================
```