### PR TITLE
Add pricing v3 free tier variant to `BillingSubscriptionType`

### DIFF
--- a/neon_api/schema.py
+++ b/neon_api/schema.py
@@ -432,6 +432,7 @@ class BillingSubscriptionType(Enum):
     scale = 'scale'
     business = 'business'
     vercel_pg_legacy = 'vercel_pg_legacy'
+    free_v3 = 'free_v3'
 
 
 class BillingPaymentMethod(Enum):


### PR DESCRIPTION
Users on the new free tier account get the following Pydantic validation error when calling `.me()` due to the lack of the new `free_v3` variant in the `BillingSubscriptionType` enum.

```python
1 validation error for CurrentUserInfoResponse
billing_account.subscription_type
  Input should be 'UNKNOWN', 'direct_sales', 'aws_marketplace', 'free_v2', 'launch', 'scale', 'business' or 'vercel_pg_legacy' [type=enum, input_value='free_v3', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/enum
Error type: ValidationError
```